### PR TITLE
'ScanMulti' returns units if one command succeeds

### DIFF
--- a/scan/scan.go
+++ b/scan/scan.go
@@ -45,7 +45,9 @@ func ScanMulti(scanners []toolchain.Tool, opt Options, treeConfig map[string]int
 			return nil
 		})
 	}
-	if err := run.Wait(); err != nil {
+	err := run.Wait()
+	// Return error only if none of the commands succeeded.
+	if len(units) == 0 {
 		return nil, err
 	}
 	return units, nil


### PR DESCRIPTION
The previous behavior was for ScanMulti to fail if any of the scanners
returned an error.

Signed-off-by: Samer Masterson samer@samertm.com
