### PR TITLE
Use exec for entry point in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN mkdir -p /root/.srclib/sourcegraph.com/sourcegraph
 RUN ln -rs /srclib/src/sourcegraph.com/sourcegraph/srclib-go /root/.srclib/sourcegraph.com/sourcegraph/srclib-go
 RUN ln -rs /srclib/src/sourcegraph.com/sourcegraph/srclib-javascript /root/.srclib/sourcegraph.com/sourcegraph/srclib-javascript
 
-ENTRYPOINT /srclib/bin/src
+ENTRYPOINT ["/srclib/bin/src"]


### PR DESCRIPTION
Works for cmd line args: `docker run srclib tc list`, @zachlatta agrees
