### PR TITLE
Add raw keys for unresolved resolutions

### DIFF
--- a/dep/resolve.go
+++ b/dep/resolve.go
@@ -57,6 +57,14 @@ func (r *Resolution) KeyId() string {
 	return r.Target.ToRepoCloneURL + r.Target.ToUnit + r.Target.ToUnitType + r.Target.ToVersionString + r.Target.ToRevSpec
 }
 
+func (r *Resolution) RawKeyId() (string, error) {
+	b, err := json.Marshal(r.Raw)
+	if err != nil {
+		return "", err
+	}
+	return string(b[:]), nil
+}
+
 // Command for dep resolution has no options.
 type Command struct{}
 

--- a/src/api_cmds.go
+++ b/src/api_cmds.go
@@ -536,7 +536,10 @@ func (c *APIDepsCmd) Execute(args []string) error {
 				return fmt.Errorf("%s: %s", depfile, err)
 			}
 			for _, d := range deps {
-				key := d.KeyId()
+				key, err := d.RawKeyId()
+				if err != nil {
+					return err
+				}
 				if _, ok := depCache[key]; !ok {
 					depCache[key] = struct{}{}
 					depSlice = append(depSlice, d)


### PR DESCRIPTION
Currently unresolved resolutions have empty targets and break keyid()