### PR TITLE
unit: don't omit empty `Files` slice when marshaling.

### DIFF
--- a/unit/source_unit.go
+++ b/unit/source_unit.go
@@ -59,7 +59,7 @@ type SourceUnit struct {
 
 	// Files is all of the files that make up this source unit. Filepaths should
 	// be relative to the repository root.
-	Files []string `json:",omitempty"`
+	Files []string
 
 	// Dir is the root directory of this source unit. It is optional and maybe
 	// empty.


### PR DESCRIPTION
`sourcegraph/srclib-javascript` expects that unit json will always contain `Files` key.

Fixes sourcegraph/srclib-javascript#11.

This should have no side effects in other toolchains, but I didn't check.