### PR TITLE
toolchain: fix find failing when directory contains file symlink

### DIFF
--- a/toolchain/find.go
+++ b/toolchain/find.go
@@ -68,6 +68,17 @@ func List() ([]*Info, error) {
 			if path != dir && (name[0] == '.' || name[0] == '_') {
 				w.SkipDir()
 			} else if fi.Mode()&os.ModeSymlink != 0 {
+				// Check if symlink points to a directory.
+				if sfi, err := os.Stat(path); err == nil {
+					if !sfi.IsDir() {
+						continue
+					}
+				} else if os.IsNotExist(err) {
+					continue
+				} else {
+					return nil, err
+				}
+
 				// traverse symlinks but refer to symlinked trees' toolchains using
 				// the path to them through the original entry in SRCLIBPATH
 				dirs = append(dirs, path+"/")

--- a/toolchain/find_test.go
+++ b/toolchain/find_test.go
@@ -45,6 +45,13 @@ func TestList_program(t *testing.T) {
 		}
 	}
 
+	// Put a file symlink in srclib DIR path.
+	oldp := filepath.Join(tmpdir, "a/a/.bin/a")
+	newp := filepath.Join(tmpdir, "link")
+	if err := os.Symlink(oldp, newp); err != nil {
+		t.Fatal(err)
+	}
+
 	toolchains, err := List()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Seems like I manage to use srclib in unorthodox ways.

Basically I figured why not set $SRCLIBPATH to something like `$HOME/.srclib:$GOPATH/src` (it as it turns out not a good idea anyway).
And one of the packages had a symlink to file which broke `toolchain.List`

Before fix it would fail with:

> lstat /some/something/README.md: not a directory

if `README.md` was a symlink.
