### PR TITLE
Return error on import failure

### DIFF
--- a/src/remote_import_build_data_cmd.go
+++ b/src/remote_import_build_data_cmd.go
@@ -152,6 +152,7 @@ func (c *RemoteImportBuildCmd) Execute(args []string) error {
 				log.Printf("# Import succeeded!")
 			} else if importTask.Failure {
 				log.Printf("# Import failed!")
+				return fmt.Errorf("import failed")
 			}
 			break
 		}


### PR DESCRIPTION
Returns error if a build fails to import, instead of just logging it.