### PR TITLE
Add temp dir cmd

### DIFF
--- a/src/toolchain_cmd.go
+++ b/src/toolchain_cmd.go
@@ -292,7 +292,7 @@ func (c *ToolchainAddCmd) Execute(args []string) error {
 
 type ToolchainTempDirCmd struct {
 	Args struct {
-		ToolchainPath string `name:"TOOLCHAIN" default:"." description:"toolchain path for which to get temp dir"`
+		ToolchainPath string `name:"TOOLCHAIN" description:"toolchain path for which to get temp dir"`
 	} `positional-args:"yes" required:"yes"`
 }
 

--- a/src/toolchain_cmd.go
+++ b/src/toolchain_cmd.go
@@ -73,6 +73,15 @@ func init() {
 		log.Fatal(err)
 	}
 
+	_, err = c.AddCommand("temp-dir",
+		"get toolchain's temp dir",
+		"Get toolchain's temp directory. Creates it if it doesn't exists.",
+		&toolchainTempDirCmd,
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	_, err = c.AddCommand("install",
 		"install toolchains",
 		"Download and install toolchains",
@@ -279,6 +288,24 @@ var toolchainAddCmd ToolchainAddCmd
 
 func (c *ToolchainAddCmd) Execute(args []string) error {
 	return toolchain.Add(c.Dir, c.Args.ToolchainPath)
+}
+
+type ToolchainTempDirCmd struct {
+	Args struct {
+		ToolchainPath string `name:"TOOLCHAIN" default:"." description:"toolchain path for which to get temp dir"`
+	} `positional-args:"yes" required:"yes"`
+}
+
+var toolchainTempDirCmd ToolchainTempDirCmd
+
+func (c *ToolchainTempDirCmd) Execute(args []string) error {
+	dir, err := toolchain.TempDir(c.Args.ToolchainPath)
+	if err != nil {
+		return errors.New(brush.Red(fmt.Sprintf("Failed to get/create temp dir: %s", err)).String())
+	}
+
+	fmt.Printf(dir)
+	return nil
 }
 
 type toolchainInstaller struct {

--- a/src/toolchain_cmd.go
+++ b/src/toolchain_cmd.go
@@ -533,6 +533,6 @@ func symlinkToGopath(toolchain string) (skip string, err error) {
 		return fmt.Sprintf("toolchain dir in GOPATH (%s) is not a symlink (assuming you intentionally cloned the toolchain repo to your GOPATH; not modifying it)", gopathDir), nil
 	}
 
-	log.Printf("Symlinked toolchain %s into your GOPATH at", toolchain, gopathDir)
+	log.Printf("Symlinked toolchain %s into your GOPATH at %s", toolchain, gopathDir)
 	return "", nil
 }

--- a/toolchain/temp_dir.go
+++ b/toolchain/temp_dir.go
@@ -1,0 +1,38 @@
+package toolchain
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"sourcegraph.com/sourcegraph/srclib"
+)
+
+// TEMPDIRNAME is directory under SRCLIBPATH where to store temp directories for toolchains.
+const TEMPDIRNAME = "tmp"
+
+// TempDir returns toolchains temp directory. Directory is created it doesn't
+// exist.
+func TempDir(toolchainPath string) (string, error) {
+	tc, err := Lookup(toolchainPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf(
+				"get toolchain failed: %s (is %s a srclib toolchain repository?)",
+				err,
+				toolchainPath,
+			)
+		}
+		return "", err
+	}
+
+	srclibpathEntry := strings.SplitN(srclib.Path, ":", 2)[0]
+	tmpDir := filepath.Join(srclibpathEntry, TEMPDIRNAME, tc.Path)
+
+	if err := os.MkdirAll(tmpDir, 0700); err != nil {
+		return "", err
+	}
+
+	return tmpDir, nil
+}

--- a/toolchain/temp_dir.go
+++ b/toolchain/temp_dir.go
@@ -9,8 +9,8 @@ import (
 	"sourcegraph.com/sourcegraph/srclib"
 )
 
-// TEMPDIRNAME is directory under SRCLIBPATH where to store temp directories for toolchains.
-const TEMPDIRNAME = "tmp"
+// TempDirName is directory under SRCLIBPATH where to store temp directories for toolchains.
+const TempDirName = ".tmp"
 
 // TempDir returns toolchains temp directory. Directory is created it doesn't
 // exist.
@@ -28,7 +28,7 @@ func TempDir(toolchainPath string) (string, error) {
 	}
 
 	srclibpathEntry := strings.SplitN(srclib.Path, ":", 2)[0]
-	tmpDir := filepath.Join(srclibpathEntry, TEMPDIRNAME, tc.Path)
+	tmpDir := filepath.Join(srclibpathEntry, TempDirName, tc.Path)
 
 	if err := os.MkdirAll(tmpDir, 0700); err != nil {
 		return "", err


### PR DESCRIPTION
Should still decide on temp dir location. Using `~/.srclib/tmp` doesn't seem to be wise since `src` also looks for toolchains there.