### PR TITLE
Updating homepage and Sourcegraph-Atom installation

### DIFF
--- a/docs/sources/plugins/atom.md
+++ b/docs/sources/plugins/atom.md
@@ -17,6 +17,25 @@ as the language toolchains for the individual languages that you wish to use.
 
 Follow the [srclib installation instructions here](../install.md#install-srclib)
 
-### Installing from source
-Clone the `https://github.com/sourcegraph/sourcegraph-atom.git` repository into `~/.atom/packages/sourcegraph-atom/`.
-Run `apm install` in the directory. Restart atom - the plugin should now be ready to use.
+
+<br>
+
+### Command-line installation
+
+The recommended install method is to install it using apm:
+```
+apm install sourcegraph-atom
+```
+
+<br>
+
+### Installing using the Atom packages
+
+Install the sourcegraph-atom package in the UI:
+
+1. Open Atom, navigate to `Edit > Preferences`. In the `Settings` page, select `Install`.
+
+2. Search for package `sourcegraph-atom` and choose `install`
+
+
+<br>

--- a/docs/theme/home.html
+++ b/docs/theme/home.html
@@ -7,7 +7,7 @@
   <div class="container">
     <div class="row">
       <div class="col-sm-7">
-        <h1><img src="/images/srclib_symbol_white.svg" height=47 width=47 style="margin-left:-8px"><strong>srclib</strong> is a polyglot code analysis library, built with hackability in mind.</h1>
+        <h1><img alt="srclib symbol" src="../images/srclib_symbol.svg"/> <strong>srclib</strong> is a hackable, multi-language code analysis library for building better code tools.</h1>
         <p>srclib makes developer tools like editor plugins and code search
         better. It supports things like <strong>jump to
         definition</strong>, <strong>find usages</strong>, <strong>type
@@ -17,7 +17,7 @@
         tools that consume this format.
 
         <p>srclib originated inside <a target="_blank" href="https://sourcegraph.com">&#x2731; Sourcegraph</a>, where it powers intelligent code search over hundreds of thousands of projects.
-          
+
         <p>
 
         {% include "newsletter2.html" %}
@@ -418,13 +418,16 @@
 <div class="team section">
   <div class="container">
     <div>
-      From the team that brought you
+      Brought to you by the <img src="/images/srclib_symbol_white.svg" height=47 width=47 style="margin-left:-8px"><strong>srclib</strong> team.
       <br>
       <br>
-      <a href="http://sourcegraph.com"><img src="/images/sourcegraphlogo-white.svg"></img></a>
-      <br><br>
-      <a target="_blank" href="https://twitter.com/sqs">@sqs</a>, <a target="_blank" href="https://twitter.com/beyang">@beyang</a>,
-      <a target="_blank" href="https://twitter.com/charles_vickery">@charles_vickery</a>, <a target="_blank" href="https://twitter.com/varunprime">@varunprime</a>
+      <a target="_blank" href="https://twitter.com/sqs">@sqs</a>,
+      <a target="_blank" href="https://twitter.com/beyang">@beyang</a>,
+      <a target="_blank" href="https://twitter.com/charles_vickery">@charles_vickery</a>,
+      <a target="_blank" href="https://twitter.com/varunprime">@varunprime</a>,
+      <a target="_blank" href="https://twitter.com/_tolli">@_tolli</a>,
+      <a target="_blank" href="https://twitter.com/maikumori">@maikumori</a>,
+      <a target="_blank" href="https://twitter.com/samertm">@samertm</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Dear  friends,

The homepage will have the same first alinea  as docs/overview.md and it will contain our Twitter names. Furthermore the Sourcegraph-Atom doc has 2 install methods now.


Best regards,
Jelmer de Reus