### PR TITLE
Docsoverview

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ APIs and formats, it is difficult to reuse your plugin for other languages or
 editors.
 
 We call this the **M-by-N problem**: given *M* editors and *N* languages, we
-need to write (on the order of) *M*&times;*N* plugins to get good tooling in 
+need to write (on the order of) *M*&times;*N* plugins to get good tooling in
 every case. That number gets large quickly, and it's why we suffer from poor
 developer tools.
 
@@ -69,3 +69,10 @@ srclib by installing an editor plugin in your editor of choice. [See all editor 
 ## License
 Sourcegraph is licensed under the [MIT License](https://tldrlegal.com/license/mit-license).
 More information in the LICENSE file.
+
+
+## Contributing
+
+In case you want to get involved and start hacking on srclib bugs and features or write your own toolchain, sign up on [Slack](http://srclib.slack.com) and introduce yourself to the #General channel.
+<br>
+We are more than happy to meet new contributors and to help people to get started on srclib hacking.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,6 @@ More information in the LICENSE file.
 
 ## Contributing
 
-In case you want to get involved and start hacking on srclib bugs and features or write your own toolchain, sign up on [Slack](http://srclib.slack.com) and introduce yourself to the #General channel.
-<br>
-We are more than happy to meet new contributors and to help people to get started on srclib hacking.
+**In case you want to get involved and start hacking on srclib bugs and features or write your own toolchain, [sign up for Slack](http://slackin.srclib.org/) and access it on  [srclib.slack.com](http://srclib.slack.com) .**
+
+Don't forget to introduce yourself on the #General channel. We are more than happy to meet new contributors and to help people to get started.

--- a/docs/sources/overview.md
+++ b/docs/sources/overview.md
@@ -70,3 +70,81 @@ consume this format.
 </ul><!-- <ul class="action-buttons list-unstyled"> -->
 </div>
 </div>
+
+
+<br>
+## Why srclib
+
+The why of srclib is explained in more detail on the [homepage](https://srclib.org/). In short it is designed for the purpose of making software development tools more independent from the languages they support, and to enable standard functionalities in these tools like jump to definition, find usages, type inference, and documentation generation.
+
+On this page you will find an explanation of how srclib works and links to more specific information.
+
+
+<br>
+## What srclib does
+
+Srclib exposes a command-line API that you can use to analyze source code in the supported languages. The results of the analysis are stored in a well defined, language-independent format (JSON).
+
+Language-specific toolchains have been created to analyze source code. By using language-specific toolchains in combination with the `src` command, it can analyze code regardless of the language, and due to its common JSON format
+
+
+
+<br>
+#### Tasks that srclib can do
+
+When running `src make` on the command-line or when making API calls from extensions, in essence the following tasks are performed by the `src` binary:
+
+
+* **Scanning** runs before all other tools and finds all source units of the language (e.g., Python packages, Ruby gems, etc.) in a directory tree. Scanners also determine which other tools to call on each source unit.
+
+
+* **Dependency resolution** resolves raw dependencies to git/hg clone URIs, subdirectories, and commit IDs if possible (e.g., foo@0.2.1 to github.com/alice/foo commit ID abcd123).
+
+* **Graphing** performs type checking/inference and static analysis (called “graphing”) on the language’s source units and dumps data about all definitions and references.
+
+<br>
+More detailed information on the `src make` command can be found in the `src` [documentation](api/make.md) The API commands are described in more detail on the [API overview](api/overview.md) page.
+
+
+<br>
+#### Data exchange and format
+
+All `src` tools and language toolchains interact by reading on standard input and writing to standard output.
+
+Results of the various analysis tasks are stored in the path `$GOPATH/.srclib/` in folders with a corresponding name to the API calls. The data model and the JSON exchange format is described in more detail in the [API data model](api/overview.md).
+
+
+<br>
+#### Components of srclib
+
+The following components make up the core functionality of srclib:
+
+* The `src` command-line analysis tool
+* The `src api` for interacting with external applications like e.g. editor plugins
+* language-specific toolchains
+* common data exchange format
+
+<br>
+You can enjoy and use the functionality of srclib with
+
+* editor plugins (jump to definition, lookup definitions on sourcegraph.com)
+* a web service like sourcegraph.com
+* your own extensions to srclib
+
+
+<br>
+## Getting started with srclib
+
+
+**Download and install**
+
+Check out the [installation guide](install.md) to get started with the installation of srclib.
+
+<br>
+**Get an editor plugin**
+
+There are srclib plugins for many editors. You can scroll to the top of this page and click on one of the links.
+
+<br>
+## Contributing
+In case you want to get involved and start hacking on srclib bugs and features or write your own toolchain, sign up on [Slack](http://srclib.slack.com) and introduce yourself to the #General channel. We are more than happy to meet new contributors and to help people to get started on srclib hacking.

--- a/docs/sources/overview.md
+++ b/docs/sources/overview.md
@@ -75,9 +75,9 @@ consume this format.
 <br>
 ## Why srclib
 
-The why of srclib is explained in more detail on the [homepage](https://srclib.org/). In short it is designed for the purpose of making software development tools more independent from the languages they support, and to enable standard functionalities in these tools like jump to definition, find usages, type inference, and documentation generation.
+Srclib is designed for the purpose of making software development tools more independent from the languages they support, and to enable standard functionalities in all these tools like jump to definition, find usages, type inference, and documentation generation.
 
-On this page you will find an explanation of how srclib works and links to more specific information.
+The why of srclib is explained in more detail on the [homepage](https://srclib.org/). On this page you will find an explanation of what srclib consists of, how it is used and links to more specific information.
 
 
 

--- a/docs/sources/overview.md
+++ b/docs/sources/overview.md
@@ -80,42 +80,9 @@ The why of srclib is explained in more detail on the [homepage](https://srclib.o
 On this page you will find an explanation of how srclib works and links to more specific information.
 
 
-<br>
-## What srclib does
-
-Srclib exposes a command-line API that you can use to analyze source code in the supported languages. The results of the analysis are stored in a well defined, language-independent format (JSON).
-
-Language-specific toolchains have been created to analyze source code. By using language-specific toolchains in combination with the `src` command, it can analyze code regardless of the language, and due to its common JSON format
-
-
 
 <br>
-#### Tasks that srclib can do
-
-When running `src make` on the command-line or when making API calls from extensions, in essence the following tasks are performed by the `src` binary:
-
-
-* **Scanning** runs before all other tools and finds all source units of the language (e.g., Python packages, Ruby gems, etc.) in a directory tree. Scanners also determine which other tools to call on each source unit.
-
-
-* **Dependency resolution** resolves raw dependencies to git/hg clone URIs, subdirectories, and commit IDs if possible (e.g., foo@0.2.1 to github.com/alice/foo commit ID abcd123).
-
-* **Graphing** performs type checking/inference and static analysis (called “graphing”) on the language’s source units and dumps data about all definitions and references.
-
-<br>
-More detailed information on the `src make` command can be found in the `src` [documentation](api/make.md) The API commands are described in more detail on the [API overview](api/overview.md) page.
-
-
-<br>
-#### Data exchange and format
-
-All `src` tools and language toolchains interact by reading on standard input and writing to standard output.
-
-Results of the various analysis tasks are stored in the path `$GOPATH/.srclib/` in folders with a corresponding name to the API calls. The data model and the JSON exchange format is described in more detail in the [API data model](api/overview.md).
-
-
-<br>
-#### Components of srclib
+## Components of srclib
 
 The following components make up the core functionality of srclib:
 
@@ -133,8 +100,52 @@ You can enjoy and use the functionality of srclib with
 
 
 <br>
-## Getting started with srclib
+## How srclib works
 
+Srclib exposes a command-line API that you can use to analyze source code in the supported languages. The results of the analysis are stored in a well defined, language-independent format (JSON).
+
+By using language-specific toolchains in combination with the `src` command, it can analyze code regardless of the language, and due to its common JSON format interaction with other tools is made much easier.
+
+
+<br>
+## Using srclib
+####running the `src make` command
+
+When running `src make` on the command-line or when making API calls from extensions, in essence the following tasks are performed by the `src` binary:
+
+
+* **Scanning** runs before all other tools and finds all source units of the language (e.g., Python packages, Ruby gems, etc.) in a directory tree. Scanners also determine which other tools to call on each source unit.
+
+
+* **Dependency resolution** resolves raw dependencies to git/hg clone URIs, subdirectories, and commit IDs if possible (e.g., foo@0.2.1 to github.com/alice/foo commit ID abcd123).
+
+* **Graphing** performs type checking/inference and static analysis (called “graphing”) on the language’s source units and dumps data about all definitions and references.
+
+For more detailed information on this process have a look at the `src make` [documentation](api/make.md) .
+
+
+####Using the srclib API
+
+The srclib API has been developed to allow the components of srclib to be called from extensions like editor plugins, and to enable a standard set of features.
+
+The API interacts with a language toolchain to support one or more of the following features:
+* Jump to definition
+* Show examples from sourcegraph.com
+
+The API commands are described in more detail on the [API overview](api/overview.md) page.
+
+
+<br>
+#### Data exchange and format
+
+All `src` tools and language toolchains interact by reading on standard input and writing to standard output.
+
+Results of the various analysis tasks are stored in the path `$GOPATH/.srclib/` in folders with a corresponding name to the API calls. The data model and the JSON exchange format is described in more detail in the [API data model](api/overview.md).
+
+
+
+<br>
+## Getting started
 
 **Download and install**
 
@@ -147,4 +158,6 @@ There are srclib plugins for many editors. You can scroll to the top of this pag
 
 <br>
 ## Contributing
-In case you want to get involved and start hacking on srclib bugs and features or write your own toolchain, sign up on [Slack](http://srclib.slack.com) and introduce yourself to the #General channel. We are more than happy to meet new contributors and to help people to get started on srclib hacking.
+In case you want to get involved and start hacking on srclib bugs and features or write your own toolchain, sign up on [Slack](http://srclib.slack.com) and introduce yourself to the #General channel.
+<br>
+We are more than happy to meet new contributors and to help people to get started on srclib hacking.

--- a/docs/sources/overview.md
+++ b/docs/sources/overview.md
@@ -156,7 +156,23 @@ Check out the [installation guide](install.md) to get started with the installat
 
 There are srclib plugins for many editors. You can scroll to the top of this page and click on one of the links.
 
-<br>
+<div class="row">
+  <div class="col-md-12">
+    <p>
+    <a href="/plugins/emacs"><button class="btn btn-primary"><img style="height: 1em;" src="/images/editors/emacs.svg"> Emacs</button></a>
+    <a href="/plugins/sublimetext"><button class="btn btn-primary"><img style="height: 1em;" src="/images/editors/sublime.png"> Sublime</button></a>
+    <a href="/plugins/atom"><button class="btn btn-primary"><img style="height: 1em;" style="height: 1em;" src="/images/editors/atom.png"> Atom</button></a>
+    <button data-toggle="popover" data-placement="top" data-content="Vim support is not yet implemented" type="button" class="btn btn-default btn-disabled">
+      <img class="desaturate" style="height: 1em;" src="/images/editors/vim.svg"> Vim
+    </button>
+
+    <p>Interested in building a plugin for an editor srclib doesn't yet
+    support? <a target="_blank" href="https://twitter.com/srclib">Let us
+    know</a>&mdash;we'd love to help!</p><br>
+
+  </div>
+</div>
+
 ## Contributing
 In case you want to get involved and start hacking on srclib bugs and features or write your own toolchain, sign up on [Slack](http://srclib.slack.com) and introduce yourself to the #General channel.
 <br>

--- a/docs/sources/overview.md
+++ b/docs/sources/overview.md
@@ -108,7 +108,6 @@ By using language-specific toolchains in combination with the `src` command, it 
 
 
 <br>
-## Using srclib
 ####running the `src make` command
 
 When running `src make` on the command-line or when making API calls from extensions, in essence the following tasks are performed by the `src` binary:
@@ -123,7 +122,7 @@ When running `src make` on the command-line or when making API calls from extens
 
 For more detailed information on this process have a look at the `src make` [documentation](api/make.md) .
 
-
+<br>
 ####Using the srclib API
 
 The srclib API has been developed to allow the components of srclib to be called from extensions like editor plugins, and to enable a standard set of features.

--- a/docs/theme/community.html
+++ b/docs/theme/community.html
@@ -6,7 +6,7 @@
 
 <div class="communitycontainer">
   <div>
-    <a href="http://slackin.srclib.org/">join us on Slack</a>
+    <a href="http://slackin.srclib.org/">get invited to the srclib Slack team</a>
     <hr>
     <a href="https://github.com/sourcegraph/srclib">srclib on GitHub</a>
     <hr>

--- a/docs/theme/community.html
+++ b/docs/theme/community.html
@@ -6,6 +6,8 @@
 
 <div class="communitycontainer">
   <div>
+    <a href="http://slackin.srclib.org/">join us on Slack</a>
+    <hr>
     <a href="https://github.com/sourcegraph/srclib">srclib on GitHub</a>
     <hr>
     <a href="https://groups.google.com/forum/#!forum/srclib-dev">srclib-dev mailing list</a>

--- a/docs/theme/home.html
+++ b/docs/theme/home.html
@@ -352,9 +352,9 @@
 
     <h2>Use srclib as:</h2>
     <ul>
-      <li><a href="#install-an-editor-plugin">An editor plugin</a></li>
+      <li><a href="#install-an-editor-plugin">An editor plugin</a> (currently for <a href="/plugins/atom">Atom</a>, <a href="/plugins/emacs">Emacs</a>, <a href="/plugins/sublimetext">Sublime</a>)</li>
       <li>
-        <a href="/api/describe">A command line tool</a> (e.g.,
+        <a href="/api/overview">A command line tool</a> (e.g.,
         <code>
             $ src api describe --file myfile.py --start-byte 123
         </code>


### PR DESCRIPTION
Extend the documentation overview  page. Add slack to the homepage and docs and community page.

README.md
docs/sources/overview.md
docs/theme/home.html
docs/theme/community.html