### PR TITLE
Windows fixes

### DIFF
--- a/config/external.go
+++ b/config/external.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"sourcegraph.com/sourcegraph/srclib"
 	"sourcegraph.com/sourcegraph/srclib/toolchain"
@@ -30,7 +29,7 @@ func SrclibPathConfig() (*External, error) {
 	var x External
 
 	// Try reading from .srclibconfig.
-	dir := strings.SplitN(srclib.Path, ":", 2)[0]
+	dir := filepath.SplitList(srclib.Path)[0]
 	configFile := filepath.Join(dir, srclibconfigFile)
 	f, err := os.Open(configFile)
 	if os.IsNotExist(err) {

--- a/config/validate.go
+++ b/config/validate.go
@@ -19,7 +19,7 @@ func (c *Tree) validate() error {
 			if filepath.IsAbs(p) {
 				return ErrInvalidFilePath
 			}
-			if p == ".." || strings.HasPrefix(p, "../") {
+			if p == ".." || strings.HasPrefix(p, ".."+string(filepath.Separator)) {
 				return ErrInvalidFilePath
 			}
 		}

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -1,16 +1,25 @@
 package config
 
 import (
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"sourcegraph.com/sourcegraph/srclib/unit"
 )
 
 func TestTree_validate(t *testing.T) {
+	var absPath string
+	if runtime.GOOS == "windows" {
+		absPath = "C:\\foo"
+	} else {
+		absPath = "/foo"
+	}
+
 	tests := map[string]*Tree{
-		"absolute path":                &Tree{SourceUnits: []*unit.SourceUnit{{Files: []string{"/foo"}}}},
-		"relative path above root":     &Tree{SourceUnits: []*unit.SourceUnit{{Files: []string{"../foo"}}}},
-		"bad path after being cleaned": &Tree{SourceUnits: []*unit.SourceUnit{{Files: []string{"foo/bar/../../../../baz"}}}},
+		"absolute path":                &Tree{SourceUnits: []*unit.SourceUnit{{Files: []string{absPath}}}},
+		"relative path above root":     &Tree{SourceUnits: []*unit.SourceUnit{{Files: []string{filepath.Join("..", "foo")}}}},
+		"bad path after being cleaned": &Tree{SourceUnits: []*unit.SourceUnit{{Files: []string{filepath.Join("foo", "bar", "..", "..", "..", "..", "baz")}}}},
 	}
 
 	for label, tree := range tests {

--- a/env.go
+++ b/env.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"sourcegraph.com/sourcegraph/srclib/util"
 )
@@ -35,7 +34,7 @@ func init() {
 	}
 
 	if CacheDir == "" {
-		dirs := strings.SplitN(Path, ":", 2)
+		dirs := filepath.SplitList(Path)
 		CacheDir = filepath.Join(dirs[0], ".cache")
 	}
 }

--- a/flagutil/marshal.go
+++ b/flagutil/marshal.go
@@ -56,5 +56,6 @@ func marshalArgsInGroup(group *flags.Group, prefix string) ([]string, error) {
 		}
 		args = append(args, groupArgs...)
 	}
+
 	return args, nil
 }

--- a/graph/repo.go
+++ b/graph/repo.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"path/filepath"
+	"path"
 	"strings"
 )
 
@@ -35,10 +35,10 @@ func TryMakeURI(cloneURL string) (string, error) {
 		return "", fmt.Errorf("MakeURI(%q): %s", cloneURL, err)
 	}
 
-	path := strings.TrimSuffix(url.Path, ".git")
-	path = filepath.Clean(path)
-	path = strings.TrimSuffix(path, "/")
-	return strings.ToLower(url.Host) + path, nil
+	uri := strings.TrimSuffix(url.Path, ".git")
+	uri = path.Clean(uri)
+	uri = strings.TrimSuffix(uri, "/")
+	return strings.ToLower(url.Host) + uri, nil
 }
 
 // URIEqual returns true if a and b are equal, based on a case insensitive

--- a/plan/data.go
+++ b/plan/data.go
@@ -1,7 +1,6 @@
 package plan
 
 import (
-	"fmt"
 	"path/filepath"
 
 	"sourcegraph.com/sourcegraph/srclib/buildstore"
@@ -13,5 +12,5 @@ func RepositoryCommitDataFilename(emptyData interface{}) string {
 }
 
 func SourceUnitDataFilename(emptyData interface{}, u *unit.SourceUnit) string {
-	return filepath.Clean(fmt.Sprintf("%s/%s.%s", u.Name, u.Type, buildstore.DataTypeSuffix(emptyData)))
+	return filepath.Join(u.Name, u.Type+"."+buildstore.DataTypeSuffix(emptyData))
 }

--- a/plan/makefile.go
+++ b/plan/makefile.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os/exec"
+	"path/filepath"
 
 	"strings"
 
@@ -151,9 +152,9 @@ func CreateMakefile(buildDataDir string, buildStore buildstore.RepoBuildStore, v
 					// if it is, we simply swap the revision in the file name with the
 					// previous valid revision. If it isn't, we prefix p with
 					// "../[previous-revision]".
-					p := strings.Split(rule.Target(), "/")
+					p := strings.Split(rule.Target(), string(filepath.Separator))
 					if len(p) > 2 &&
-						strings.Join(p[0:2], "/") == buildDataDir &&
+						filepath.Join(p[0:2]...) == buildDataDir &&
 						len(p[1]) == 40 { // HACK: Mercurial and Git both use 40-char hashes.
 						// p is prefixed by "data-dir/vcs-commit-id"
 						p[1] = prevCommitID
@@ -162,7 +163,7 @@ func CreateMakefile(buildDataDir string, buildStore buildstore.RepoBuildStore, v
 					}
 
 					rules[i] = &cachedRule{
-						cachedPath: strings.Join(p, "/"),
+						cachedPath: filepath.Join(p...),
 						target:     rule.Target(),
 						unit:       u,
 						prereqs:    rule.Prereqs(),

--- a/plan/makefile_test.go
+++ b/plan/makefile_test.go
@@ -2,6 +2,7 @@ package plan_test
 
 import (
 	"bytes"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -36,13 +37,15 @@ func TestCreateMakefile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := `
-all: testdata/n/t.graph.json testdata/n/t.depresolve.json
+	sep := string(filepath.Separator)
 
-testdata/n/t.graph.json: testdata/n/t.unit.json f
+	want := `
+all: testdata` + sep + `n` + sep + `t.graph.json testdata` + sep + `n` + sep + `t.depresolve.json
+
+testdata` + sep + `n` + sep + `t.graph.json: testdata` + sep + `n` + sep + `t.unit.json f
 	src tool  "tc" "t" < $< | src internal normalize-graph-data --unit-type "t" --dir . 1> $@
 
-testdata/n/t.depresolve.json: testdata/n/t.unit.json
+testdata` + sep + `n` + sep + `t.depresolve.json: testdata` + sep + `n` + sep + `t.unit.json
 	src tool  "tc" "t" < $^ 1> $@
 
 .DELETE_ON_ERROR:

--- a/src/api_cmds.go
+++ b/src/api_cmds.go
@@ -148,7 +148,7 @@ func prepareCommandContext(file string) (commandContext, error) {
 	if file == "" {
 		return commandContext{}, errors.New("prepareCommandContext: file cannot be empty")
 	}
-	if file == "." || file[len(file)-1] == os.PathSeparator {
+	if file == "." || file[len(file)-1] == filepath.Separator {
 		isDir = true
 	}
 	file, err = filepath.Abs(file)
@@ -159,7 +159,7 @@ func prepareCommandContext(file string) (commandContext, error) {
 	// the path separator to it to presrve filepath.Dir's
 	// semantics.
 	if isDir {
-		file += string(os.PathSeparator)
+		file += string(filepath.Separator)
 	}
 
 	repo, err := OpenRepo(filepath.Dir(file))

--- a/src/build_data_cmds.go
+++ b/src/build_data_cmds.go
@@ -230,7 +230,7 @@ func (c *BuildDataListCmd) Execute(args []string) error {
 
 		var suffix string
 		if fi.IsDir() {
-			suffix = "/"
+			suffix = string(filepath.Separator)
 		}
 
 		var urlStr string

--- a/src/cli.go
+++ b/src/cli.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 
 	"strconv"
 
@@ -59,7 +60,8 @@ func newAPIClient(ua *userEndpointAuth, cache bool) *sourcegraph.Client {
 
 	var transport http.RoundTripper
 	if cache {
-		transport = http.RoundTripper(httpcache.NewTransport(diskcache.New("/tmp/srclib-cache")))
+		tempDir := filepath.Join(os.TempDir(), "srclib-cache")
+		transport = http.RoundTripper(httpcache.NewTransport(diskcache.New(tempDir)))
 	} else {
 		transport = http.DefaultTransport
 	}

--- a/src/doall_cmd_test.go
+++ b/src/doall_cmd_test.go
@@ -23,7 +23,7 @@ func init() {
 		log.Fatal(err)
 	}
 	if !strings.HasSuffix(d, filepath.Join("srclib", "src")) {
-		log.Fatalf("directory %s must end with \"srclib"+string(os.PathSeparator)+"src\"", d)
+		log.Fatalf("directory %s must end with \"srclib"+string(filepath.Separator)+"src\"", d)
 	}
 	testdataPath = filepath.Join(d, "..", "testdata")
 	srclibPath = filepath.Join(testdataPath, "srclibpath")

--- a/src/lint_cmd.go
+++ b/src/lint_cmd.go
@@ -102,10 +102,10 @@ func (c *LintCmd) Execute(args []string) error {
 						// Infer source unit name from file path (the
 						// path components after .srclib-cache until
 						// the basename).
-						pcs := strings.Split(absPath, string(os.PathSeparator))
+						pcs := strings.Split(absPath, string(filepath.Separator))
 						for i, pc := range pcs {
 							if pc == buildstore.BuildDataDirName && len(pcs) > i+2 {
-								unitName = filepath.Clean(strings.Join(pcs[i+2:len(pcs)-1], "/"))
+								unitName = filepath.Join(pcs[i+2 : len(pcs)-1]...)
 								break
 							}
 						}
@@ -114,7 +114,7 @@ func (c *LintCmd) Execute(args []string) error {
 					var commitID string
 					if !c.NoCheckFiles {
 						// Infer commit ID from file path (the path component after .srclib-cache).
-						pcs := strings.Split(absPath, string(os.PathSeparator))
+						pcs := strings.Split(absPath, string(filepath.Separator))
 						for i, pc := range pcs {
 							if pc == buildstore.BuildDataDirName && len(pcs) > i+1 {
 								commitID = pcs[i+1]

--- a/src/misc.go
+++ b/src/misc.go
@@ -29,7 +29,7 @@ func (d Directory) Complete(match string) []flags.Completion {
 	var dirs []flags.Completion
 	for _, name := range names {
 		if fi, err := os.Stat(name); err == nil && fi.Mode().IsDir() {
-			dirs = append(dirs, flags.Completion{Item: name + "/"})
+			dirs = append(dirs, flags.Completion{Item: name + string(filepath.Separator)})
 		}
 	}
 	return dirs
@@ -49,5 +49,5 @@ func (d Directory) String() string {
 	if file == "." || file == ".." {
 		return dir + file
 	}
-	return dir + file + string(os.PathSeparator)
+	return dir + file + string(filepath.Separator)
 }

--- a/src/query_cmd.go
+++ b/src/query_cmd.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -43,7 +44,7 @@ type QueryCmd struct {
 
 var queryCmd QueryCmd
 
-var historyFile = "/tmp/.srclibq_history"
+var historyFile = filepath.Join(os.TempDir(), ".srclibq_history")
 
 var activeContext commandContext
 

--- a/src/toolchain_cmd.go
+++ b/src/toolchain_cmd.go
@@ -414,7 +414,7 @@ func installGoToolchain() error {
 		return skippedToolchain{toolchain, "no GOPATH set (assuming Go is not installed and you don't want the Go toolchain)"}
 	}
 
-	srclibpathDir := filepath.Join(strings.Split(srclib.Path, ":")[0], toolchain) // toolchain dir under SRCLIBPATH
+	srclibpathDir := filepath.Join(filepath.SplitList(srclib.Path)[0], toolchain) // toolchain dir under SRCLIBPATH
 
 	if err := os.MkdirAll(filepath.Dir(srclibpathDir), 0700); err != nil {
 		return err
@@ -442,7 +442,7 @@ func installGoToolchain() error {
 func installRubyToolchain() error {
 	const toolchain = "sourcegraph.com/sourcegraph/srclib-ruby"
 
-	srclibpathDir := filepath.Join(strings.Split(srclib.Path, ":")[0], toolchain) // toolchain dir under SRCLIBPATH
+	srclibpathDir := filepath.Join(filepath.SplitList(srclib.Path)[0], toolchain) // toolchain dir under SRCLIBPATH
 
 	if _, err := exec.LookPath("ruby"); isExecErrNotFound(err) {
 		return skippedToolchain{toolchain, "no `ruby` in PATH (assuming you don't have Ruby installed and you don't want the Ruby toolchain)"}
@@ -467,7 +467,7 @@ func installRubyToolchain() error {
 func installJavaScriptToolchain() error {
 	const toolchain = "sourcegraph.com/sourcegraph/srclib-javascript"
 
-	srclibpathDir := filepath.Join(strings.Split(srclib.Path, ":")[0], toolchain) // toolchain dir under SRCLIBPATH
+	srclibpathDir := filepath.Join(filepath.SplitList(srclib.Path)[0], toolchain) // toolchain dir under SRCLIBPATH
 
 	if _, err := exec.LookPath("node"); isExecErrNotFound(err) {
 		return skippedToolchain{toolchain, "no `node` in PATH (assuming you don't have Node.js installed and you don't want the JavaScript toolchain)"}
@@ -499,7 +499,7 @@ func installPythonToolchain() error {
 		}
 	}
 
-	srclibpathDir := filepath.Join(strings.Split(srclib.Path, ":")[0], toolchain) // toolchain dir under SRCLIBPATH
+	srclibpathDir := filepath.Join(filepath.SplitList(srclib.Path)[0], toolchain) // toolchain dir under SRCLIBPATH
 	log.Println("Downloading or updating Python toolchain in", srclibpathDir)
 	if err := execCmd("src", "toolchain", "get", "-u", toolchain); err != nil {
 		return err
@@ -542,9 +542,9 @@ func symlinkToGopath(toolchain string) (skip string, err error) {
 		return "", fmt.Errorf("GOPATH not set")
 	}
 
-	srcDir := filepath.Join(strings.Split(gopath, ":")[0], "src")
+	srcDir := filepath.Join(filepath.SplitList(gopath)[0], "src")
 	gopathDir := filepath.Join(srcDir, toolchain)
-	srclibpathDir := filepath.Join(strings.Split(srclib.Path, ":")[0], toolchain)
+	srclibpathDir := filepath.Join(filepath.SplitList(srclib.Path)[0], toolchain)
 
 	if fi, err := os.Lstat(gopathDir); os.IsNotExist(err) {
 		log.Printf("mkdir -p %s", filepath.Dir(gopathDir))
@@ -553,6 +553,7 @@ func symlinkToGopath(toolchain string) (skip string, err error) {
 		}
 		log.Printf("ln -s %s %s", srclibpathDir, gopathDir)
 		if err := os.Symlink(srclibpathDir, gopathDir); err != nil {
+			log.Printf("Symlink failed %s", err)
 			return "", err
 		}
 	} else if err != nil {

--- a/src/units_cmd.go
+++ b/src/units_cmd.go
@@ -157,5 +157,5 @@ func pathHasAnyPrefix(path string, prefixes []string) bool {
 func pathHasPrefix(path, prefix string) bool {
 	path = filepath.Clean(path)
 	prefix = filepath.Clean(prefix)
-	return prefix == "." || path == prefix || strings.HasPrefix(path, prefix+"/")
+	return prefix == "." || path == prefix || strings.HasPrefix(path, prefix+string(filepath.Separator))
 }

--- a/toolchain/add.go
+++ b/toolchain/add.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"sourcegraph.com/sourcegraph/srclib"
 )
@@ -31,7 +30,7 @@ func Add(dir, toolchainPath string, opt *AddOpt) error {
 		return err
 	}
 
-	srclibpathEntry := strings.SplitN(srclib.Path, ":", 2)[0]
+	srclibpathEntry := filepath.SplitList(srclib.Path)[0]
 	targetDir := filepath.Join(srclibpathEntry, toolchainPath)
 
 	if err := os.MkdirAll(filepath.Dir(targetDir), 0700); err != nil {

--- a/toolchain/find.go
+++ b/toolchain/find.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
-	"strings"
 
 	"github.com/kr/fs"
 	"sourcegraph.com/sourcegraph/srclib"
@@ -47,7 +47,7 @@ func List() ([]*Info, error) {
 	var found []*Info
 	seen := map[string]string{}
 
-	dirs := strings.Split(srclib.Path, ":")
+	dirs := filepath.SplitList(srclib.Path)
 
 	// maps symlinked trees to their original path
 	origDirs := map[string]string{}
@@ -81,10 +81,11 @@ func List() ([]*Info, error) {
 
 				// traverse symlinks but refer to symlinked trees' toolchains using
 				// the path to them through the original entry in SRCLIBPATH
-				dirs = append(dirs, path+"/")
-				origDirs[path+"/"] = dir
+				dirs = append(dirs, path+string(filepath.Separator))
+				origDirs[path+string(filepath.Separator)] = dir
 			} else if fi.Mode().IsDir() {
 				// Check for Srclibtoolchain file in this dir.
+
 				if _, err := os.Stat(filepath.Join(path, ConfigFilename)); os.IsNotExist(err) {
 					continue
 				} else if err != nil {
@@ -133,11 +134,16 @@ func newInfo(toolchainPath, dir, configFile string) (*Info, error) {
 	}
 
 	prog := filepath.Join(".bin", filepath.Base(toolchainPath))
+
+	if runtime.GOOS == "windows" {
+		prog += ".exe"
+	}
+
 	if fi, err := os.Stat(filepath.Join(dir, prog)); os.IsNotExist(err) {
 		prog = ""
 	} else if err != nil {
 		return nil, err
-	} else if !(fi.Mode().Perm()&0111 > 0) {
+	} else if runtime.GOOS != "windows" && !(fi.Mode().Perm()&0111 > 0) {
 		return nil, fmt.Errorf("installed toolchain program %q is not executable (+x)", prog)
 	}
 
@@ -155,11 +161,11 @@ func newInfo(toolchainPath, dir, configFile string) (*Info, error) {
 func lookInPaths(pattern string, paths string) ([]string, error) {
 	var found []string
 	seen := map[string]struct{}{}
-	for _, dir := range strings.Split(paths, ":") {
+	for _, dir := range filepath.SplitList(paths) {
 		if dir == "" {
 			dir = "."
 		}
-		matches, err := filepath.Glob(dir + "/" + pattern)
+		matches, err := filepath.Glob(filepath.Join(dir, pattern))
 		if err != nil {
 			return nil, err
 		}

--- a/toolchain/find_test.go
+++ b/toolchain/find_test.go
@@ -24,16 +24,16 @@ func TestList_program(t *testing.T) {
 
 	files := map[string]os.FileMode{
 		// ok
-		"a/a/.bin/a":          0700,
-		"a/a/Srclibtoolchain": 0700,
+		filepath.Join("a", "a", ".bin", "a"):       0700,
+		filepath.Join("a", "a", "Srclibtoolchain"): 0700,
 
 		// not executable
-		"b/b/.bin/z":          0600,
-		"b/b/Srclibtoolchain": 0600,
+		filepath.Join("b", "b", ".bin", "z"):       0600,
+		filepath.Join("b", "b", "Srclibtoolchain"): 0600,
 
 		// not in .bin
-		"c/c/c":               0700,
-		"c/c/Srclibtoolchain": 0700,
+		filepath.Join("c", "c", "c"):               0700,
+		filepath.Join("c", "c", "Srclibtoolchain"): 0700,
 	}
 	for f, mode := range files {
 		f = filepath.Join(tmpdir, f)
@@ -46,7 +46,7 @@ func TestList_program(t *testing.T) {
 	}
 
 	// Put a file symlink in srclib DIR path.
-	oldp := filepath.Join(tmpdir, "a/a/.bin/a")
+	oldp := filepath.Join(tmpdir, "a", "a", ".bin", "a")
 	newp := filepath.Join(tmpdir, "link")
 	if err := os.Symlink(oldp, newp); err != nil {
 		t.Fatal(err)
@@ -58,7 +58,7 @@ func TestList_program(t *testing.T) {
 	}
 
 	got := toolchainPathsWithProgramOrDockerfile(toolchains)
-	want := []string{"a/a"}
+	want := []string{filepath.Join("a", "a")}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got toolchains %v, want %v", got, want)
 	}
@@ -78,13 +78,13 @@ func TestList_docker(t *testing.T) {
 
 	files := map[string]struct{}{
 		// ok
-		"a/a/Dockerfile": struct{}{}, "a/a/Srclibtoolchain": struct{}{},
+		filepath.Join("a", "a", "Dockerfile"): struct{}{}, filepath.Join("a", "a", "Srclibtoolchain"): struct{}{},
 
 		// no Srclibtoolchain
-		"b/b/Dockerfile": struct{}{},
+		filepath.Join("b", "b", "Dockerfile"): struct{}{},
 
 		// ok (no Dockerfile)
-		"c/c/Srclibtoolchain": struct{}{},
+		filepath.Join("c", "c", "Srclibtoolchain"): struct{}{},
 	}
 	for f := range files {
 		if err := os.MkdirAll(filepath.Join(tmpdir, filepath.Dir(f)), 0700); err != nil {
@@ -101,7 +101,7 @@ func TestList_docker(t *testing.T) {
 	}
 
 	got := toolchainPathsWithProgramOrDockerfile(toolchains)
-	want := []string{"a/a"}
+	want := []string{filepath.Join("a", "a")}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got toolchains %v, want %v", got, want)
 	}

--- a/toolchain/get.go
+++ b/toolchain/get.go
@@ -21,7 +21,7 @@ func Get(path string, update bool) (*Info, error) {
 		return tc, err
 	}
 
-	dir := strings.SplitN(srclib.Path, ":", 2)[0]
+	dir := filepath.SplitList(srclib.Path)[0]
 	toolchainDir := filepath.Join(dir, path)
 
 	if fi, err := os.Stat(toolchainDir); os.IsNotExist(err) {

--- a/toolchain/temp_dir.go
+++ b/toolchain/temp_dir.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"sourcegraph.com/sourcegraph/srclib"
 )
@@ -27,7 +26,7 @@ func TempDir(toolchainPath string) (string, error) {
 		return "", err
 	}
 
-	srclibpathEntry := strings.SplitN(srclib.Path, ":", 2)[0]
+	srclibpathEntry := filepath.SplitList(srclib.Path)[0]
 	tmpDir := filepath.Join(srclibpathEntry, TempDirName, tc.Path)
 
 	if err := os.MkdirAll(tmpDir, 0700); err != nil {

--- a/toolchain/toolchain.go
+++ b/toolchain/toolchain.go
@@ -166,7 +166,7 @@ func newDockerToolchain(path, dir, dockerfile, hostVolumeDir string) (*dockerToo
 	return &dockerToolchain{
 		dir:           dir,
 		dockerfile:    dockerfile,
-		imageName:     strings.Replace(path, "/", "-", -1),
+		imageName:     strings.Replace(path, string(filepath.Separator), "-", -1),
 		docker:        dc,
 		hostVolumeDir: hostVolumeDir,
 	}, nil


### PR DESCRIPTION
First round of Windows fixes. So far this is mostly simple fixes like dealing with path separators and path list separators properly.

There's some iffy stuff in the toolchain command code (which I also couldn't get working just yet due to symlink issues), but most of the rest of it should be pretty safe. I'll call that out in the comments on those lines.

The tests all pass locally for me on *nix, but that doesn't mean it's all happily working. Warrants some close scrutiny just due to how many things this touches.

Part of #149