### PR TITLE
cmd/src: Make it clearer that an error occurred

### DIFF
--- a/cmd/src/src.go
+++ b/cmd/src/src.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"runtime/pprof"
+	"strings"
 
 	_ "sourcegraph.com/sourcegraph/srclib/dep"
 	_ "sourcegraph.com/sourcegraph/srclib/scan"
@@ -26,6 +28,7 @@ func main() {
 	}
 
 	if err := src.Main(); err != nil {
+		fmt.Fprintf(os.Stderr, "FAILED: %s - %s\n", strings.Join(os.Args, " "), err.Error())
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Writes `os.Args` and `err.Error()` to `stderr`. This way you can also see
failures in the subprocesses that src manages.

An example of failure output is

```
$ src make
fork/exec /Users/keegan/.srclib/sourcegraph.com/sourcegraph/srclib-python/.env/bin/virtualenv: no such file or directory
exit status 1
EOF
FAILED: src internal normalize-graph-data --unit-type PythonProgram --dir . - EOF
.srclib-cache/16a4943ad6c9d7cc333e64c7d1d366b2c461144e/PythonProgram.graph.json: command failed: src tool --methods program,docker "sourcegraph.com/sourcegraph/srclib-python" "graph" < .srclib-cache/16a4943ad6c9d7cc333e64c7d1d366b2c461144e/PythonProgram.unit.json | src internal normalize-graph-data --unit-type "PythonProgram" --dir . 1> .srclib-cache/16a4943ad6c9d7cc333e64c7d1d366b2c461144e/PythonProgram.graph.json (exit status 1)
command failed: src tool --methods program,docker "sourcegraph.com/sourcegraph/srclib-python" "graph" < .srclib-cache/16a4943ad6c9d7cc333e64c7d1d366b2c461144e/PythonProgram.unit.json | src internal normalize-graph-data --unit-type "PythonProgram" --dir . 1> .srclib-cache/16a4943ad6c9d7cc333e64c7d1d366b2c461144e/PythonProgram.graph.json (exit status 1)
FAILED: src make - command failed: src tool --methods program,docker "sourcegraph.com/sourcegraph/srclib-python" "graph" < .srclib-cache/16a4943ad6c9d7cc333e64c7d1d366b2c461144e/PythonProgram.unit.json | src internal normalize-graph-data --unit-type "PythonProgram" --dir . 1> .srclib-cache/16a4943ad6c9d7cc333e64c7d1d366b2c461144e/PythonProgram.graph.json (exit status 1)
```