### PR TITLE
Make `src make` more informative

### DIFF
--- a/dep/rule.go
+++ b/dep/rule.go
@@ -2,6 +2,7 @@ package dep
 
 import (
 	"fmt"
+	"log"
 	"path/filepath"
 
 	"sourcegraph.com/sourcegraph/makex"
@@ -34,6 +35,9 @@ func makeDepRules(c *config.Tree, dataDir string, existing []makex.Rule, opt pla
 		}
 
 		rules = append(rules, &ResolveDepsRule{dataDir, u, toolRef, opt})
+		if opt.Verbose {
+			log.Printf("Created %v rule for %v %v", depresolveOp, toolRef.Toolchain, u.ID())
+		}
 	}
 	return rules, nil
 }

--- a/grapher/rule.go
+++ b/grapher/rule.go
@@ -2,6 +2,7 @@ package grapher
 
 import (
 	"fmt"
+	"log"
 	"path/filepath"
 
 	"sourcegraph.com/sourcegraph/makex"
@@ -35,6 +36,10 @@ func makeGraphRules(c *config.Tree, dataDir string, existing []makex.Rule, opt p
 		}
 
 		rules = append(rules, &GraphUnitRule{dataDir, u, toolRef, opt})
+		if opt.Verbose {
+			log.Printf("Created %v rule for %v %v", graphOp, toolRef.Toolchain, u.ID())
+		}
+
 	}
 	return rules, nil
 }

--- a/plan/makefile.go
+++ b/plan/makefile.go
@@ -20,6 +20,8 @@ type Options struct {
 	// When NoCache is true, all files are rebuilt instead of only
 	// the ones associated with changed source units.
 	NoCache bool
+
+	Verbose bool
 }
 
 type RuleMaker func(c *config.Tree, dataDir string, existing []makex.Rule, opt Options) ([]makex.Rule, error)

--- a/plan/makefile.go
+++ b/plan/makefile.go
@@ -107,6 +107,9 @@ func CreateMakefile(buildDataDir string, buildStore buildstore.RepoBuildStore, v
 		if err != nil {
 			return nil, fmt.Errorf("rule maker %s: %s", name, err)
 		}
+		if opt.Verbose {
+			log.Printf("%v: Created %d rule(s)", name, len(rules))
+		}
 		if !opt.NoCache {
 			// When cached builds are enabled, we replace all rules whose source unit
 			// hasn't changed between commits with a rule that copies the build

--- a/src/make_cmd.go
+++ b/src/make_cmd.go
@@ -2,19 +2,20 @@ package src
 
 import (
 	"io"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
-
-	"sourcegraph.com/sourcegraph/makex"
-
 	"strings"
+
+	"github.com/aybabtme/color/brush"
 
 	"sourcegraph.com/sourcegraph/srclib"
 	"sourcegraph.com/sourcegraph/srclib/buildstore"
 	"sourcegraph.com/sourcegraph/srclib/config"
 	"sourcegraph.com/sourcegraph/srclib/flagutil"
 	"sourcegraph.com/sourcegraph/srclib/plan"
+	"sourcegraph.com/sourcegraph/makex"
 )
 
 func init() {
@@ -83,7 +84,16 @@ func (c *MakeCmd) Execute(args []string) error {
 	if c.DryRun {
 		return mk.DryRun(os.Stdout)
 	}
-	return mk.Run()
+	err = mk.Run()
+	switch {
+	case c.Quiet:
+		// Skip output
+	case err == nil:
+		fmt.Println(brush.Green("MAKE SUCCESS"))
+	case err != nil:
+		fmt.Println(brush.DarkRed("MAKE FAILURE"))
+	}
+	return err
 }
 
 // CreateMakefile creates a Makefile to build a tree. The cwd should

--- a/src/make_cmd.go
+++ b/src/make_cmd.go
@@ -37,8 +37,9 @@ type MakeCmd struct {
 	ToolchainExecOpt `group:"execution"`
 	BuildCacheOpt    `group:"build cache"`
 
-	Quiet  bool `short:"q" long:"quiet" description:"silence all output"`
-	DryRun bool `short:"n" long:"dry-run" description:"print what would be done and exit"`
+	Quiet   bool `short:"q" long:"quiet" description:"silence all output"`
+	Verbose bool `short:"v" long:"verbose" description:"show more verbose output"`
+	DryRun  bool `short:"n" long:"dry-run" description:"print what would be done and exit"`
 
 	Dir Directory `short:"C" long:"directory" description:"change to DIR before doing anything" value-name:"DIR"`
 
@@ -70,6 +71,7 @@ func (c *MakeCmd) Execute(args []string) error {
 
 	mkConf := &makex.Default
 	mk := mkConf.NewMaker(mf, goals...)
+	mk.Verbose = c.Verbose
 
 	if c.Quiet {
 		mk.RuleOutput = func(r makex.Rule) (out io.WriteCloser, err io.WriteCloser, logger *log.Logger) {

--- a/src/make_cmd.go
+++ b/src/make_cmd.go
@@ -57,7 +57,7 @@ func (c *MakeCmd) Execute(args []string) error {
 		}
 	}
 
-	mf, err := CreateMakefile(c.ToolchainExecOpt, c.BuildCacheOpt)
+	mf, err := CreateMakefile(c.ToolchainExecOpt, c.BuildCacheOpt, c.Verbose)
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func (c *MakeCmd) Execute(args []string) error {
 // CreateMakefile creates a Makefile to build a tree. The cwd should
 // be the root of the tree you want to make (due to some probably
 // unnecessary assumptions that CreateMaker makes).
-func CreateMakefile(execOpt ToolchainExecOpt, cacheOpt BuildCacheOpt) (*makex.Makefile, error) {
+func CreateMakefile(execOpt ToolchainExecOpt, cacheOpt BuildCacheOpt, verbose bool) (*makex.Makefile, error) {
 	localRepo, err := OpenRepo(".")
 	if err != nil {
 		return nil, err
@@ -117,6 +117,7 @@ func CreateMakefile(execOpt ToolchainExecOpt, cacheOpt BuildCacheOpt) (*makex.Ma
 	mf, err := plan.CreateMakefile(buildDataDir, buildStore, localRepo.VCSType, treeConfig, plan.Options{
 		ToolchainExecOpt: strings.Join(toolchainExecOptArgs, " "),
 		NoCache:          cacheOpt.NoCacheWrite,
+		Verbose:          verbose,
 	})
 	if err != nil {
 		return nil, err

--- a/src/makefile_cmd.go
+++ b/src/makefile_cmd.go
@@ -21,12 +21,13 @@ func init() {
 type MakefileCmd struct {
 	ToolchainExecOpt `group:"execution"`
 	BuildCacheOpt    `group:"build cache"`
+	Verbose bool     `short:"v" long:"verbose" description:"show more verbose output"`
 }
 
 var makefileCmd MakefileCmd
 
 func (c *MakefileCmd) Execute(args []string) error {
-	mf, err := CreateMakefile(c.ToolchainExecOpt, c.BuildCacheOpt)
+	mf, err := CreateMakefile(c.ToolchainExecOpt, c.BuildCacheOpt, c.Verbose)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* --verbose flag for make and makefile subcommands
* Extra logging around target creation in verbose mode
* Final output line with colourized info indicating build success or failure