### PR TITLE
graph: Handle file paths passed to `TryMakeURI`

### DIFF
--- a/graph/repo.go
+++ b/graph/repo.go
@@ -35,7 +35,7 @@ func TryMakeURI(cloneURL string) (string, error) {
 		return "", fmt.Errorf("MakeURI(%q): %s", cloneURL, err)
 	} else if url.Path == "" || url.Path == "/" {
 		return "", fmt.Errorf("MakeURI(%q): missing path from URL", cloneURL)
-	} else if url.Host == "" && !strings.Contains(strings.Split(url.Path, "/")[0], ".") {
+	} else if url.Host == "" && (url.Path[0] == '/' || !strings.Contains(strings.Trim(url.Path, "/"), "/")) {
 		// We ensure our Path doesn't look like the output of TryMakeURI
 		// so that the output of this function is a fixed point.
 		// ie TryMakeURI("github.com/user/repo") == ("github.com/user/repo", nil),

--- a/graph/repo.go
+++ b/graph/repo.go
@@ -33,6 +33,14 @@ func TryMakeURI(cloneURL string) (string, error) {
 	url, err := url.Parse(cloneURL)
 	if err != nil {
 		return "", fmt.Errorf("MakeURI(%q): %s", cloneURL, err)
+	} else if url.Path == "" || url.Path == "/" {
+		return "", fmt.Errorf("MakeURI(%q): missing path from URL", cloneURL)
+	} else if url.Host == "" && !strings.Contains(strings.Split(url.Path, "/")[0], ".") {
+		// We ensure our Path doesn't look like the output of TryMakeURI
+		// so that the output of this function is a fixed point.
+		// ie TryMakeURI("github.com/user/repo") == ("github.com/user/repo", nil),
+		// not an error.
+		return "", fmt.Errorf("MakeURI(%q): missing host from URL", cloneURL)
 	}
 
 	path := strings.TrimSuffix(url.Path, ".git")

--- a/graph/repo.go
+++ b/graph/repo.go
@@ -32,15 +32,15 @@ func TryMakeURI(cloneURL string) (string, error) {
 
 	url, err := url.Parse(cloneURL)
 	if err != nil {
-		return "", fmt.Errorf("MakeURI(%q): %s", cloneURL, err)
+		return "", err
 	} else if url.Path == "" || url.Path == "/" {
-		return "", fmt.Errorf("MakeURI(%q): missing path from URL", cloneURL)
+		return "", fmt.Errorf("determining URI from repo clone URL failed: missing path from URL (%q)", cloneURL)
 	} else if url.Host == "" && (url.Path[0] == '/' || !strings.Contains(strings.Trim(url.Path, "/"), "/")) {
 		// We ensure our Path doesn't look like the output of TryMakeURI
 		// so that the output of this function is a fixed point.
 		// ie TryMakeURI("github.com/user/repo") == ("github.com/user/repo", nil),
 		// not an error.
-		return "", fmt.Errorf("MakeURI(%q): missing host from URL", cloneURL)
+		return "", fmt.Errorf("determining URI from repo clone URL failed: missing host from URL (%q)", cloneURL)
 	}
 
 	path := strings.TrimSuffix(url.Path, ".git")

--- a/graph/repo_test.go
+++ b/graph/repo_test.go
@@ -17,8 +17,10 @@ func TestTryMakeURI(t *testing.T) {
 		{"ssh://hg@bitbucket.org/org/repo", "bitbucket.org/org/repo"},
 		{"https://user@bitbucket.org/org/repo", "bitbucket.org/org/repo"},
 		{"/foo/bar", ""},
-		{"foo/github.com/user/repo", ""},
-		{"/foo/github.com/user/repo", ""},
+		{"https://gitrepos/foo/bar", "gitrepos/foo/bar"},
+		{"gitrepos/foo/bar", "gitrepos/foo/bar"},
+		{"gitrepos/", ""},
+		{"/gitrepos/foo/bar", ""},
 		{"http://foo.com/", ""},
 		{"http://foo.com/bar?baz#qux", "foo.com/bar"},
 	}

--- a/graph/repo_test.go
+++ b/graph/repo_test.go
@@ -2,7 +2,7 @@ package graph
 
 import "testing"
 
-func TestMakeURI(t *testing.T) {
+func TestTryMakeURI(t *testing.T) {
 	tests := []struct {
 		cloneURL string
 		want     string
@@ -12,12 +12,21 @@ func TestMakeURI(t *testing.T) {
 		{"http://bitbucket.org/user/repo", "bitbucket.org/user/repo"},
 		{"https://bitbucket.org/user/repo", "bitbucket.org/user/repo"},
 		{"bitbucket.org/user/repo", "bitbucket.org/user/repo"},
+		{"", ""},
+		{"http://sourcegraph.com/user/repo", "sourcegraph.com/user/repo"},
+		{"ssh://hg@bitbucket.org/org/repo", "bitbucket.org/org/repo"},
+		{"https://user@bitbucket.org/org/repo", "bitbucket.org/org/repo"},
+		{"/foo/bar", ""},
+		{"foo/github.com/user/repo", ""},
+		{"/foo/github.com/user/repo", ""},
+		{"http://foo.com/", ""},
+		{"http://foo.com/bar?baz#qux", "foo.com/bar"},
 	}
 
 	for _, test := range tests {
-		got := MakeURI(test.cloneURL)
+		got, _ := TryMakeURI(test.cloneURL)
 		if test.want != got {
-			t.Errorf("%s: want URI %s, got %s", test.cloneURL, test.want, got)
+			t.Errorf("%q: want URI %q, got %q", test.cloneURL, test.want, got)
 		}
 	}
 }


### PR DESCRIPTION
If a user clones a local repo with `git clone /path/to/repo /path/to/destrepo` the remote URL is a path `/path/to/destrepo`. We didn't error out from `TryMakeURI` on these inputs.