### PR TITLE
toolchain: use more descriptive error in `Lookup`.

### DIFF
--- a/toolchain/find.go
+++ b/toolchain/find.go
@@ -26,7 +26,7 @@ func Lookup(path string) (*Info, error) {
 	}
 
 	if len(matches) == 0 {
-		return nil, os.ErrNotExist
+		return nil, &os.PathError{Op: "toolchain.Lookup", Path: path, Err: os.ErrNotExist}
 	}
 	if len(matches) > 1 {
 		return nil, fmt.Errorf("shadowed toolchain path %q (toolchains: %v)", path, matches)


### PR DESCRIPTION
Fixes #157. Shouldn't contain breaking changes.

Personally I'd define `ErrToolchainNotFound` and use that, but as sqs mentioned using `&os.PathError` is backwards compatible.

I checked across sourgraph projects and none is using error string matching instead of `os.IsNotFound` so everything looks good.