### PR TITLE
toolchain: add support for prebuilt toolchain bundles

### DIFF
--- a/cli/toolchain_cmd.go
+++ b/cli/toolchain_cmd.go
@@ -457,8 +457,8 @@ func installToolchains(langs []toolchainInstaller) error {
 	for _, l := range langs {
 		fmt.Println(brush.Cyan(l.name + " " + strings.Repeat("=", 78-len(l.name))).String())
 		if err := l.fn(); err != nil {
-			if err, ok := err.(skippedToolchain); ok {
-				fmt.Printf("%s\n", brush.Yellow(err.Error()))
+			if err2, ok := err.(skippedToolchain); ok {
+				fmt.Printf("%s\n", brush.Yellow(err2.Error()))
 			} else {
 				fmt.Printf("%s\n", brush.Red(fmt.Sprintf("failed to install/upgrade %s toolchain: %s", l.name, err)))
 			}

--- a/cli/toolchain_cmd.go
+++ b/cli/toolchain_cmd.go
@@ -666,7 +666,6 @@ func installToolchainFromBundle(name, toolchainPath, bundleURL string) (err erro
 					)
 				}
 			case <-done:
-				log.Printf("Finished downloading")
 				return
 			}
 		}
@@ -679,6 +678,8 @@ func installToolchainFromBundle(name, toolchainPath, bundleURL string) (err erro
 	if err != nil {
 		return err
 	}
+
+	log.Printf("Finished downloading")
 
 	log.Printf("Unarchiving %s toolchain bundle at %s", name, outputFile)
 	var unbundleCmd ToolchainUnbundleCmd

--- a/env.go
+++ b/env.go
@@ -26,6 +26,13 @@ var (
 	CommandName = "srclib"
 )
 
+// PathEntries returns first colon-separated entries in Path
+// (SRCLIBPATH). It is guaranteed to have at least one non-empty
+// element.
+func PathEntries() []string {
+	return strings.Split(Path, ":")
+}
+
 func init() {
 	if Path == "" {
 		homeDir := util.CurrentUserHomeDir()

--- a/toolchain/add.go
+++ b/toolchain/add.go
@@ -20,8 +20,10 @@ func Add(dir, toolchainPath string, opt *AddOpt) error {
 		opt = &AddOpt{}
 	}
 	if !opt.Force {
-		if _, err := Lookup(toolchainPath); !os.IsNotExist(err) {
+		if _, err := Lookup(toolchainPath); err == nil {
 			return fmt.Errorf("a toolchain already exists at toolchain path %q", toolchainPath)
+		} else if !os.IsNotExist(err) {
+			return err
 		}
 	}
 

--- a/toolchain/add.go
+++ b/toolchain/add.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"sourcegraph.com/sourcegraph/srclib"
 )
@@ -31,8 +30,7 @@ func Add(dir, toolchainPath string, opt *AddOpt) error {
 		return err
 	}
 
-	srclibpathEntry := strings.SplitN(srclib.Path, ":", 2)[0]
-	targetDir := filepath.Join(srclibpathEntry, toolchainPath)
+	targetDir := filepath.Join(srclib.PathEntries()[0], toolchainPath)
 
 	if err := os.MkdirAll(filepath.Dir(targetDir), 0700); err != nil {
 		return err

--- a/toolchain/bundle.go
+++ b/toolchain/bundle.go
@@ -1,0 +1,391 @@
+package toolchain
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/bzip2"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/kr/fs"
+
+	"sort"
+)
+
+// Variant represents a single permutation of variables that produces
+// a single product (for toolchain bundles); e.g., {"os":"linux",
+// "arch": "amd64"}.
+type Variant map[string]string
+
+func (v Variant) String() string {
+	keys := make([]string, 0, len(v))
+	for k := range v {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys) // sort for determinism and canonical representation
+
+	parts := make([]string, len(keys))
+	for i, key := range keys {
+		parts[i] = key + "-" + v[key]
+	}
+	return strings.Join(parts, "_")
+}
+
+// ParseVariant parses a variant string (e.g., "arch-386_os-linux")
+// into its key-value pairs ({"arch": "386", "os": "linux"}).
+func ParseVariant(s string) Variant {
+	if s == "" {
+		return Variant{}
+	}
+	pairs := strings.Split(s, "_")
+	m := make(map[string]string, len(pairs))
+	for _, pair := range pairs {
+		parts := strings.SplitN(pair, "-", 2)
+		if len(parts) == 1 {
+			// Assume empty.
+			parts = append(parts, "")
+		}
+		k := parts[0]
+		v := parts[1]
+		m[k] = v
+	}
+	return m
+}
+
+// Bundle builds all variants of the toolchain and creates
+// separate archive files for each variant in a temporary
+// directory. It returns a list of variants and the archive files
+// produced from them.
+//
+// If variants is nil, all variants specified in the Srclibtoolchain
+// file are built.
+func Bundle(toolchainDir, outputDir string, variants []Variant, dryRun, verbose bool) (bundles []string, err error) {
+	toolchainDir = filepath.Clean(toolchainDir)
+	if toolchainDir == "." {
+		toolchainDir, err = filepath.Abs(toolchainDir)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	info := &Info{Dir: toolchainDir, ConfigFile: ConfigFilename}
+	conf, err := info.ReadConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	if conf.Bundle == nil {
+		return nil, fmt.Errorf("toolchain at %s does not support bundling (%s file has no Bundle property)", toolchainDir, ConfigFilename)
+	}
+
+	if variants == nil {
+		variants = conf.Bundle.Variants
+	}
+
+	toolchainName := filepath.Base(toolchainDir)
+	for _, variant := range variants {
+		archiveFile := filepath.Join(outputDir, toolchainName+"__bundle__"+variant.String()+".tar.gz")
+
+		if !dryRun {
+			if err := os.MkdirAll(filepath.Dir(archiveFile), 0700); err != nil {
+				return nil, err
+			}
+		}
+
+		if verbose {
+			log.Printf("Creating bundle variant %v...", variant)
+		}
+		if err := createBundleVariant(info.Dir, archiveFile, conf, variant, dryRun, verbose); err != nil {
+			return nil, err
+		}
+
+		bundles = append(bundles, archiveFile)
+
+		log.Println()
+		log.Println()
+	}
+
+	return bundles, nil
+}
+
+// createBundleVariant builds and archives a single variant of a
+// toolchain.
+func createBundleVariant(toolchainDir, archiveFile string, conf *Config, variant Variant, dryRun, verbose bool) (err error) {
+	// Build.
+	for _, shellCmd := range conf.Bundle.Commands {
+		shellCmd = os.Expand(shellCmd, func(key string) string {
+			v, present := variant[key]
+			if present {
+				return v
+			}
+			return fmt.Sprintf("${%s}", key) // remain uninterpolated, pass to `sh -c`
+		})
+
+		var buf bytes.Buffer
+		cmd := exec.Command("sh", "-c", shellCmd)
+		cmd.Dir = toolchainDir
+		cmd.Env = append(os.Environ(), variantToEnvVars(variant)...)
+		if verbose {
+			log.Printf("\t> %s", shellCmd)
+			cmd.Stdout = os.Stderr
+			cmd.Stderr = os.Stderr
+		} else {
+			cmd.Stdout = &buf
+			cmd.Stderr = &buf
+		}
+		if dryRun {
+			continue
+		}
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("exec %v failed (%s)\n%s", cmd.Args, err, buf.String())
+		}
+	}
+
+	// Create archive.
+	log.Printf("\tCreating archive file %s", archiveFile)
+	if dryRun {
+		return nil
+	}
+	f, err := os.Create(archiveFile)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err2 := f.Close(); err2 != nil && err == nil {
+			err = err2
+		}
+	}()
+
+	gw := gzip.NewWriter(f)
+	defer func() {
+		if err2 := gw.Close(); err2 != nil && err == nil {
+			err = err2
+		}
+	}()
+
+	tw := tar.NewWriter(gw)
+	defer func() {
+		if err2 := tw.Close(); err2 != nil && err == nil {
+			err = err2
+		}
+	}()
+
+	for _, pathGlob := range conf.Bundle.Paths {
+		paths, err := expandBundlePath(filepath.Join(toolchainDir, pathGlob))
+		if err != nil {
+			return err
+		}
+		for _, path := range paths {
+			fi2, err := os.Stat(path)
+			if err != nil {
+				return err
+			}
+
+			if !fi2.Mode().IsRegular() && !fi2.Mode().IsDir() {
+				log.Printf("Warning: while creating bundle archive for toolchain in %s (variant %v), encountered a file at %q that is neither file, dir nor symlink; skipping. (Special files are skipped, for security reasons.)", toolchainDir, variant, path)
+				continue
+			}
+
+			relPath, err := filepath.Rel(toolchainDir, path)
+			if err != nil {
+				return err
+			}
+
+			var linkName string // only set for symlinks
+			if fi2.Mode()&os.ModeSymlink != 0 {
+				dest, err := os.Readlink(path)
+				if err != nil {
+					return err
+				}
+				linkName = dest
+			}
+
+			hdr, err := tar.FileInfoHeader(fi2, linkName)
+			if err != nil {
+				return err
+			}
+			if strings.HasSuffix(hdr.Name, "/") {
+				relPath += "/"
+			}
+			hdr.Name = relPath
+
+			// Ensure it's writable by us.
+			hdr.Mode |= 0200
+
+			if err := tw.WriteHeader(hdr); err != nil {
+				return err
+			}
+
+			if fi2.Mode().IsRegular() {
+				f2, err := os.Open(path)
+				if err != nil {
+					return err
+				}
+				if _, err := io.Copy(tw, f2); err != nil {
+					f2.Close()
+					return err
+				}
+				if err := f2.Close(); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return err
+}
+
+// expandBundlePath calls filepath.Glob first, then recursively adds
+// descendents of any directories specified.
+func expandBundlePath(pathGlob string) ([]string, error) {
+	paths, err := filepath.Glob(pathGlob)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, path := range paths {
+		fi, err := os.Stat(path)
+		if err != nil {
+			return nil, err
+		}
+
+		if fi.Mode().IsDir() {
+			w := fs.Walk(path)
+			for w.Step() {
+				if err := w.Err(); err != nil {
+					return nil, err
+				}
+				paths = append(paths, w.Path())
+			}
+		}
+	}
+
+	return paths, nil
+}
+
+func variantToEnvVars(v Variant) []string {
+	var s []string
+	for k, v := range v {
+		s = append(s, k+"="+v)
+	}
+	return s
+}
+
+// Unbundle unpacks the archive r to the toolchain named by the given
+// toolchain path. The archiveName indicates what type of archive r
+// contains; e.g., "foo.tar.gz" is a gzipped tar archive, "foo.tar" is
+// just a tar archive, etc. An error is returned if archiveName's
+// suffix isn't that of a recognized format.
+func Unbundle(toolchainPath, archiveName string, r io.Reader) (err error) {
+	ext := filepath.Ext(archiveName)
+	switch ext {
+	case ".tgz":
+		return Unbundle(toolchainPath, strings.TrimSuffix(archiveName, ext)+".tar.gz", r)
+	case ".gz":
+		gr, err := gzip.NewReader(r)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err2 := gr.Close(); err2 != nil && err == nil {
+				err = err2
+			}
+		}()
+		return Unbundle(toolchainPath, strings.TrimSuffix(archiveName, ext), gr)
+
+	case ".tbz2":
+		return Unbundle(toolchainPath, strings.TrimSuffix(archiveName, ext)+".tar.bz2", r)
+	case ".bz2":
+		return Unbundle(toolchainPath, strings.TrimSuffix(archiveName, ext), bzip2.NewReader(r))
+
+	case ".tar":
+
+		dir, err := Dir(toolchainPath)
+		if err != nil {
+			return err
+		}
+
+		writeTarEntry := func(hdr *tar.Header, r io.Reader) (err error) {
+			mode := hdr.FileInfo().Mode()
+
+			name := filepath.Clean(hdr.Name)
+			if strings.Contains(name, "..") {
+				return fmt.Errorf("invalid tar archive entry path %q", name)
+			}
+
+			path := filepath.Join(dir, name)
+
+			switch {
+			case mode.IsDir():
+				return os.MkdirAll(path, mode.Perm())
+
+			case mode.IsRegular():
+				if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+					return err
+				}
+
+				// Check file perms to overwrite if needed.
+				fi, err := os.Stat(path)
+				if err == nil {
+					perm := fi.Mode().Perm()
+					if perm&0200 /* write */ == 0 {
+						if err := os.Chmod(path, perm|0200); err != nil {
+							return err
+						}
+					}
+				}
+
+				f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode.Perm())
+				if err != nil {
+					return err
+				}
+				defer func() {
+					if err2 := f.Close(); err2 != nil && err == nil {
+						err = err2
+					}
+				}()
+				if _, err := io.Copy(f, r); err != nil {
+					return err
+				}
+
+			case mode&os.ModeSymlink != 0:
+				if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+					return err
+				}
+
+				if err := os.Symlink(hdr.Linkname, path); err != nil {
+					return err
+				}
+
+			default:
+				log.Printf("Warning: while extracting bundle for toolchain %s to %s, encountered a tar entry at %q that is neither file, dir, nor symlink; skipping. (Special files are skipped, for security reasons.)", toolchainPath, dir, hdr.Name)
+
+			}
+			return nil
+		}
+
+		tr := tar.NewReader(r)
+		for {
+			hdr, err := tr.Next()
+			if err == io.EOF {
+				// end of tar archive
+				break
+			}
+			if err != nil {
+				return err
+			}
+			if err := writeTarEntry(hdr, tr); err != nil {
+				return err
+			}
+		}
+		return nil
+
+	}
+	return fmt.Errorf("bad toolchain bundle archive file %q (suffix not recognized)", archiveName)
+}

--- a/toolchain/bundle_test.go
+++ b/toolchain/bundle_test.go
@@ -1,0 +1,29 @@
+package toolchain
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestVariant(t *testing.T) {
+	tests := []struct {
+		variant Variant
+		want    string
+	}{
+		{Variant{}, ""},
+		{Variant{"x": "y"}, "x-y"},
+		{Variant{"a": "b", "x": "y", "c": "d"}, "a-b_c-d_x-y"},
+	}
+	for _, test := range tests {
+		got := test.variant.String()
+		if got != test.want {
+			t.Errorf("%v: got String %q, want %q", test.variant, got, test.want)
+			continue
+		}
+		v := ParseVariant(got)
+		if !reflect.DeepEqual(v, test.variant) {
+			t.Errorf("ParseVariant(%q): got %+v, want %+v", got, v, test.variant)
+			continue
+		}
+	}
+}

--- a/toolchain/config.go
+++ b/toolchain/config.go
@@ -9,4 +9,46 @@ const ConfigFilename = "Srclibtoolchain"
 type Config struct {
 	// Tools is the list of this toolchain's tools and their definitions.
 	Tools []*ToolInfo
+
+	// Bundle configures the way that this toolchain is built and
+	// archived. If Bundle is not set, it means that the toolchain
+	// can't be bundled.
+	Bundle *struct {
+		// Paths is a list of path globs whose matches are included in
+		// the toolchain bundle archive file (created, e.g., using
+		// "srclib toolchain bundle <PATH>"). It should contain all of
+		// the files necessary to execute the toolchain. For
+		// toolchains whose entrypoint is a static binary or JAR, this
+		// is typically the entrypoint plus any shell scripts or
+		// support files necessary.
+		//
+		// Go's filepath.Glob is used for globbing. In addition, if a
+		// dir is specified, all of its entries are included
+		// recursively.
+		//
+		// "Srclibtoolchain" and ".bin/{basename}" (where {basename}
+		// is this toolchain's path's final path component) MUST
+		// always be included in this list, or else when unarchived
+		// the bundle won't be a valid toolchain.
+		Paths []string `json:",omitempty"`
+
+		// Commands is the list of commands to run in order to build
+		// the files to archive. (E.g., "go build ...".) Sometimes
+		// these commands just consist of a "make install" or similar
+		// invocation.
+		//
+		// All commands are passed to `sh -c`.
+		Commands []string `json:",omitempty"`
+
+		// Variants is the set of possible bundles. Typically these
+		// define products such as "linux-amd64", "linux-386",
+		// "darwin-amd64", etc., for binary outputs.
+		//
+		// The key-value pairs specified in each variant are available
+		// to the commands (in the Commands list). Each command's
+		// variable references ($foo or ${foo}) are expanded using the
+		// values in the Variant, and they are run with the Variant's
+		// properties set as environment variables.
+		Variants []Variant `json:",omitempty"`
+	}
 }

--- a/toolchain/find.go
+++ b/toolchain/find.go
@@ -47,7 +47,7 @@ func List() ([]*Info, error) {
 	var found []*Info
 	seen := map[string]string{}
 
-	dirs := strings.Split(srclib.Path, ":")
+	dirs := srclib.PathEntries()
 
 	// maps symlinked trees to their original path
 	origDirs := map[string]string{}

--- a/toolchain/get.go
+++ b/toolchain/get.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"sourcegraph.com/sourcegraph/srclib"
 )
@@ -21,8 +20,7 @@ func Get(path string, update bool) (*Info, error) {
 		return tc, err
 	}
 
-	dir := strings.SplitN(srclib.Path, ":", 2)[0]
-	toolchainDir := filepath.Join(dir, path)
+	toolchainDir := filepath.Join(srclib.PathEntries()[0], path)
 
 	if fi, err := os.Stat(toolchainDir); os.IsNotExist(err) {
 		cloneURL := "https://" + path + ".git"

--- a/toolchain/get.go
+++ b/toolchain/get.go
@@ -5,33 +5,31 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-
-	"sourcegraph.com/sourcegraph/srclib"
 )
 
-// Get downloads the toolchain named by the toolchain path (if it does not
-// already exist in the SRCLIBPATH). If update is true, it uses the network to
-// update the toolchain.
+// CloneOrUpdate downloads the toolchain named by the toolchain path
+// (if it does not already exist in the SRCLIBPATH). If update is
+// true, it uses the network to update the toolchain.
 //
 // Assumes that the clone URL is "https://" + path + ".git".
-func Get(path string, update bool) (*Info, error) {
+func CloneOrUpdate(path string, update bool) (*Info, error) {
 	path = filepath.Clean(path)
-	if tc, err := Lookup(path); !os.IsNotExist(err) {
-		return tc, err
+
+	dir, err := Dir(path)
+	if err != nil {
+		return nil, err
 	}
 
-	toolchainDir := filepath.Join(srclib.PathEntries()[0], path)
-
-	if fi, err := os.Stat(toolchainDir); os.IsNotExist(err) {
+	if fi, err := os.Stat(dir); os.IsNotExist(err) {
 		cloneURL := "https://" + path + ".git"
-		cmd := exec.Command("git", "clone", cloneURL, toolchainDir)
+		cmd := exec.Command("git", "clone", cloneURL, dir)
 		cmd.Stdout, cmd.Stderr = os.Stderr, os.Stderr
 		if err := cmd.Run(); err != nil {
 			return nil, err
 		}
 	} else if update && fi.Mode().IsDir() {
 		cmd := exec.Command("git", "pull", "origin", "master")
-		cmd.Dir = toolchainDir
+		cmd.Dir = dir
 		cmd.Stdout, cmd.Stderr = os.Stderr, os.Stderr
 		if err := cmd.Run(); err != nil {
 			return nil, err
@@ -42,7 +40,7 @@ func Get(path string, update bool) (*Info, error) {
 
 	tc, err := Lookup(path)
 	if err != nil {
-		return nil, fmt.Errorf("get toolchain failed: %s (is %s a srclib toolchain repository?)", err, path)
+		return nil, fmt.Errorf("clone-or-update toolchain failed: %s (is %s a srclib toolchain repository?)", err, path)
 	}
 	return tc, nil
 }

--- a/toolchain/temp_dir.go
+++ b/toolchain/temp_dir.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"sourcegraph.com/sourcegraph/srclib"
 )
@@ -27,8 +26,7 @@ func TempDir(toolchainPath string) (string, error) {
 		return "", err
 	}
 
-	srclibpathEntry := strings.SplitN(srclib.Path, ":", 2)[0]
-	tmpDir := filepath.Join(srclibpathEntry, TempDirName, tc.Path)
+	tmpDir := filepath.Join(srclib.PathEntries()[0], TempDirName, tc.Path)
 
 	if err := os.MkdirAll(tmpDir, 0700); err != nil {
 		return "", err

--- a/toolchain/toolchain.go
+++ b/toolchain/toolchain.go
@@ -10,8 +10,27 @@ import (
 	"path/filepath"
 	"strings"
 
+	"sourcegraph.com/sourcegraph/srclib"
+
 	"github.com/fsouza/go-dockerclient"
 )
+
+// Dir returns the directory where the named toolchain lives (under
+// the SRCLIBPATH). If the toolchain already exists in any of the
+// entries of SRCLIBPATH, that directory is returned. Otherwise a
+// nonexistent directory in the first SRCLIBPATH entry is returned.
+func Dir(toolchainPath string) (string, error) {
+	toolchainPath = filepath.Clean(toolchainPath)
+
+	dir, err := lookupToolchain(toolchainPath)
+	if os.IsNotExist(err) {
+		return filepath.Join(srclib.PathEntries()[0], toolchainPath), nil
+	}
+	if err != nil {
+		err = &os.PathError{Op: "toolchain.Dir", Path: toolchainPath, Err: err}
+	}
+	return dir, err
+}
 
 // Info describes a toolchain.
 type Info struct {


### PR DESCRIPTION
Toolchain bundles are .tar.gz archives of precompiled srclib toolchains.
Binary distribution of toolchains allows people to install and use toolchains
without needing to compile them (which often requires many
difficult-to-install dependencies).

Toolchains define how their bundles are created and what bundle variants (for
cross-compilation) should be built. Then users can install the bundles by
downloading the .tar.gz archive and running
'srclib toolchain unbundle <FILE>'.

**Dependent PRs**
* https://github.com/sourcegraph/srclib-go/pull/40
* https://github.com/sourcegraph/srclib-java/pull/30