### PR TITLE
Make go generate directives work on more setups.

### DIFF
--- a/ann/ann.pb.go
+++ b/ann/ann.pb.go
@@ -11,11 +11,13 @@ It is generated from these files:
 It has these top-level messages:
 	Ann
 */
-package ann;import "encoding/json"
+package ann
 
 import proto "github.com/gogo/protobuf/proto"
 
 // discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+
+import encoding_json "encoding/json"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
@@ -50,7 +52,7 @@ type Ann struct {
 	Type string `protobuf:"bytes,8,opt,name=type,proto3" json:"Type"`
 	// Data contains arbitrary JSON data that is specific to this
 	// annotation type (e.g., the link URL for Link annotations).
-	Data json.RawMessage `protobuf:"bytes,9,opt,name=data,proto3" json:"Data,omitempty"`
+	Data encoding_json.RawMessage `protobuf:"bytes,9,opt,name=data,proto3,customtype=encoding/json.RawMessage" json:"Data,omitempty"`
 }
 
 func (m *Ann) Reset()         { *m = Ann{} }

--- a/ann/ann.proto
+++ b/ann/ann.proto
@@ -43,6 +43,5 @@ message Ann {
 
     // Data contains arbitrary JSON data that is specific to this
     // annotation type (e.g., the link URL for Link annotations).
-    bytes data = 9 [(gogoproto.jsontag) = "Data,omitempty"];
-
+    bytes data = 9 [(gogoproto.customtype) = "encoding/json.RawMessage", (gogoproto.jsontag) = "Data,omitempty"];
 };

--- a/ann/gen.go
+++ b/ann/gen.go
@@ -1,5 +1,3 @@
 package ann
 
-//go:generate protoc --proto_path=/usr/include:$HOME/src:$HOME/src/github.com/gogo/protobuf/protobuf/google/protobuf:. --gogo_out=. ann.proto
-//go:generate sed -i "s/Data \\[\\]byte/Data json.RawMessage/g" ann.pb.go
-//go:generate sed -i "s/^package ann$/package ann;import \"encoding\\/json\"/" ann.pb.go
+//go:generate gopathexec protoc -I$GOPATH/src -I$GOPATH/src/github.com/gogo/protobuf/protobuf -I. --gogo_out=. ann.proto

--- a/graph/def.pb.go
+++ b/graph/def.pb.go
@@ -16,11 +16,13 @@ It has these top-level messages:
 	Def
 	DefDoc
 */
-package graph;import "encoding/json"
+package graph
 
 import proto "github.com/gogo/protobuf/proto"
 
 // discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+
+import encoding_json "encoding/json"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
@@ -97,10 +99,7 @@ type Def struct {
 	// Data contains additional language- and toolchain-specific information
 	// about the def. Data is used to construct function signatures,
 	// import/require statements, language-specific type descriptions, etc.
-	//
-	// To use json.RawMessage:
-	// optional bytes data = 10 [(gogoproto.customtype) = "encoding/json.RawMessage", (gogoproto.jsontag) = "Data,omitempty"];
-	Data json.RawMessage `protobuf:"bytes,10,opt,name=data,proto3" json:"Data,omitempty"`
+	Data encoding_json.RawMessage `protobuf:"bytes,10,opt,name=data,proto3,customtype=encoding/json.RawMessage" json:"Data,omitempty"`
 	// Docs are docstrings for this Def. This field is not set in the
 	// Defs produced by graphers; they should emit docs in the
 	// separate Docs field on the graph.Output struct.

--- a/graph/def.proto
+++ b/graph/def.proto
@@ -84,10 +84,7 @@ message Def {
     // Data contains additional language- and toolchain-specific information
     // about the def. Data is used to construct function signatures,
     // import/require statements, language-specific type descriptions, etc.
-    //
-    // To use json.RawMessage:
-    //optional bytes data = 10 [(gogoproto.customtype) = "encoding/json.RawMessage", (gogoproto.jsontag) = "Data,omitempty"];
-    bytes data = 10 [(gogoproto.jsontag) = "Data,omitempty"];
+    bytes data = 10 [(gogoproto.customtype) = "encoding/json.RawMessage", (gogoproto.jsontag) = "Data,omitempty"];
 
     // Docs are docstrings for this Def. This field is not set in the
     // Defs produced by graphers; they should emit docs in the

--- a/graph/gen.go
+++ b/graph/gen.go
@@ -1,5 +1,3 @@
 package graph
 
-//go:generate protoc --proto_path=/usr/include:$HOME/src:$HOME/src/github.com/gogo/protobuf/protobuf/google/protobuf:../ann:. --gogo_out=. def.proto doc.proto output.proto ref.proto
-//go:generate sed -i "s/Data \\[\\]byte/Data json.RawMessage/g" def.pb.go
-//go:generate sed -i "s/^package graph$/package graph;import \"encoding\\/json\"/" def.pb.go
+//go:generate gopathexec protoc -I$GOPATH/src -I$GOPATH/src/github.com/gogo/protobuf/protobuf -I. --gogo_out=. def.proto doc.proto output.proto ref.proto

--- a/store/pb/gen.go
+++ b/store/pb/gen.go
@@ -1,4 +1,4 @@
 package pb
 
-//go:generate protoc -I../../../../../ -I../../../../../github.com/gogo/protobuf/protobuf -I../../../../../sourcegraph.com/sourcegraph/srclib/graph -I../../../../../sourcegraph.com/sourcegraph/srclib/ann -I. --gogo_out=plugins=grpc:. srcstore.proto
+//go:generate gopathexec protoc -I$GOPATH/src -I$GOPATH/src/github.com/gogo/protobuf/protobuf -I../../graph -I. --gogo_out=plugins=grpc:. srcstore.proto
 //go:generate gen-mocks -w -i=.+(Server|Client|Service)$ -o mock -outpkg mock -name_prefix= -no_pass_args=opts

--- a/unit/gen.go
+++ b/unit/gen.go
@@ -1,3 +1,3 @@
 package unit
 
-//go:generate protoc -I../../../../ -I ../../../../github.com/gogo/protobuf/protobuf -I. --gogo_out=. unit.proto
+//go:generate gopathexec protoc -I$GOPATH/src -I$GOPATH/src/github.com/gogo/protobuf/protobuf -I. --gogo_out=. unit.proto


### PR DESCRIPTION
Add support for running go generate successfully on OS X.

Add support for running go generate with multiple GOPATH workspaces.

Use `(gogoproto.customtype) = "encoding/json.RawMessage"` instead of doing it via custom sed string substitution.