### PR TITLE
perf: Query limit filter in unitstore.Refs

### DIFF
--- a/store/unit_store.go
+++ b/store/unit_store.go
@@ -103,6 +103,9 @@ func (s unitStores) Refs(f ...RefFilter) ([]*graph.Ref, error) {
 		c_unitStores_Refs_last_numUnitsQueried++
 
 		par.Do(func() error {
+			if _, moreOK := LimitRemaining(f); !moreOK {
+				return nil
+			}
 			fCopy := filtersForUnit(u, f).([]RefFilter)
 			fCopy = withImpliedUnit(fCopy, u)
 


### PR DESCRIPTION
If one of our filters is a `limiter`, then we can avoid querying additional
unit stores if our limit is reached. On a large synthetic repo (500 units) this
took query time from 15s to 6s. This was an FS backed store through sourcegraph
on my MBA. The limit used is 2. Most of the 6s time is dominated by
unmarshalling the index, rather than the queries.