### PR TITLE
Windows/Cygwin support (WIP)

### DIFF
--- a/dep/rule.go
+++ b/dep/rule.go
@@ -46,11 +46,11 @@ type ResolveDepsRule struct {
 }
 
 func (r *ResolveDepsRule) Target() string {
-	return filepath.Join(r.dataDir, plan.SourceUnitDataFilename([]*ResolvedDep{}, r.Unit))
+	return filepath.ToSlash(filepath.Join(r.dataDir, plan.SourceUnitDataFilename([]*ResolvedDep{}, r.Unit)))
 }
 
 func (r *ResolveDepsRule) Prereqs() []string {
-	return []string{filepath.Join(r.dataDir, plan.SourceUnitDataFilename(unit.SourceUnit{}, r.Unit))}
+	return []string{filepath.ToSlash(filepath.Join(r.dataDir, plan.SourceUnitDataFilename(unit.SourceUnit{}, r.Unit)))}
 }
 
 func (r *ResolveDepsRule) Recipes() []string {

--- a/flagutil/marshal.go
+++ b/flagutil/marshal.go
@@ -3,6 +3,7 @@ package flagutil
 import (
 	"fmt"
 	"strings"
+	"runtime"
 
 	"sourcegraph.com/sourcegraph/go-flags"
 )
@@ -26,7 +27,12 @@ func marshalArgsInGroup(group *flags.Group, prefix string) ([]string, error) {
 		// handle flags with both short and long (just get the long)
 		if i := strings.Index(flagStr, ", --"); i != -1 {
 			flagStr = flagStr[i+2:]
+		} else if runtime.GOOS == "windows" {
+		 	if i := strings.Index(flagStr, ", /"); i != -1 {
+				flagStr = flagStr[i+2:]
+			}
 		}
+
 
 		v := opt.Value()
 		if m, ok := v.(flags.Marshaler); ok {

--- a/grapher/rule.go
+++ b/grapher/rule.go
@@ -47,11 +47,11 @@ type GraphUnitRule struct {
 }
 
 func (r *GraphUnitRule) Target() string {
-	return filepath.Join(r.dataDir, plan.SourceUnitDataFilename(&graph.Output{}, r.Unit))
+	return filepath.ToSlash(filepath.Join(r.dataDir, plan.SourceUnitDataFilename(&graph.Output{}, r.Unit)))
 }
 
 func (r *GraphUnitRule) Prereqs() []string {
-	ps := []string{filepath.Join(r.dataDir, plan.SourceUnitDataFilename(unit.SourceUnit{}, r.Unit))}
+	ps := []string{filepath.ToSlash(filepath.Join(r.dataDir, plan.SourceUnitDataFilename(unit.SourceUnit{}, r.Unit)))}
 	ps = append(ps, r.Unit.Files...)
 	return ps
 }

--- a/src/repo_config.go
+++ b/src/repo_config.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"syscall"
 
+	"sourcegraph.com/sourcegraph/srclib/util"
 	"sourcegraph.com/sourcegraph/srclib/graph"
 )
 
@@ -99,7 +100,7 @@ func getRootDir(dir string) (rootDir string, vcsType string, err error) {
 	if err != nil {
 		return "", "", err
 	}
-	ancestors := ancestorDirsAndSelfExceptRoot(dir)
+	ancestors := util.AncestorDirs(dir, true)
 
 	vcsTypes := []string{"git", "hg"}
 	for i := len(ancestors) - 1; i >= 0; i-- {
@@ -113,26 +114,6 @@ func getRootDir(dir string) (rootDir string, vcsType string, err error) {
 		}
 	}
 	return "", "", nil
-}
-
-// ancestorDirsAndSelfExceptRoot returns a list of p's ancestor
-// directories (including itself but excluding the root ("." or "/")).
-func ancestorDirsAndSelfExceptRoot(p string) []string {
-	if p == "" {
-		return nil
-	}
-	if len(p) == 1 && (p[0] == '.' || p[0] == '/') {
-		return nil
-	}
-
-	var dirs []string
-	for i, c := range p {
-		if c == '/' {
-			dirs = append(dirs, p[:i])
-		}
-	}
-	dirs = append(dirs, p)
-	return dirs
 }
 
 // getVCSCloneURL gets the primary remote url. getVCSCloneURL returns

--- a/src/test_cmd.go
+++ b/src/test_cmd.go
@@ -200,7 +200,7 @@ func testTree(treeDir, expectedDir, actualDir string, exeMethod string, generate
 
 func checkResults(output bytes.Buffer, treeDir, actualDir, expectedDir string) error {
 	treeName := filepath.Base(treeDir)
-	out, err := exec.Command("diff", "-ur", expectedDir, actualDir).CombinedOutput()
+	out, err := exec.Command("diff", "-urw", expectedDir, actualDir).CombinedOutput()
 	if err != nil || len(out) > 0 {
 		fmt.Println(brush.Red(treeName + " FAIL").String())
 		fmt.Printf("Diff failed for %s: %s.", treeName, err)

--- a/src/toolchain_cmd.go
+++ b/src/toolchain_cmd.go
@@ -278,7 +278,7 @@ func (c *ToolchainGetCmd) Execute(args []string) error {
 }
 
 type ToolchainAddCmd struct {
-	Dir   string `long:"dir" description:"directory containing toolchain to add" value-name:"DIR"`
+	Dir   string `long:"dir" default:"." description:"directory containing toolchain to add" value-name:"DIR"`
 	Force bool   `short:"f" long:"force" description:"(dangerous) force add, overwrite existing toolchain"`
 	Args  struct {
 		ToolchainPath string `name:"TOOLCHAIN" default:"." description:"toolchain path to use for toolchain directory"`

--- a/store/def_files_index.go
+++ b/store/def_files_index.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/alecthomas/binary"
 
+	"sourcegraph.com/sourcegraph/srclib/util"
 	"sourcegraph.com/sourcegraph/srclib/graph"
 	"sourcegraph.com/sourcegraph/srclib/store/phtable"
 )
@@ -142,7 +143,7 @@ func (v filesToDefOfs) add(file string, ofs int64, perFile int) {
 		return
 	}
 	v[file] = append(v[file], ofs)
-	for _, dir := range ancestorDirsExceptRoot(file) {
+	for _, dir := range util.AncestorDirs(file, false) {
 		if len(v[dir]) < perFile {
 			v[dir] = append(v[dir], ofs)
 		}

--- a/store/misc_test.go
+++ b/store/misc_test.go
@@ -3,6 +3,8 @@ package store
 import (
 	"reflect"
 	"testing"
+
+	"sourcegraph.com/sourcegraph/srclib/util"
 )
 
 func TestAncestorDirsExceptRoot(t *testing.T) {
@@ -16,7 +18,7 @@ func TestAncestorDirsExceptRoot(t *testing.T) {
 		"a/b/c": []string{"a", "a/b"},
 	}
 	for p, want := range tests {
-		dirs := ancestorDirsExceptRoot(p)
+		dirs := util.AncestorDirs(p, false)
 		if !reflect.DeepEqual(dirs, want) {
 			t.Errorf("%v: got %v, want %v", p, dirs, want)
 		}

--- a/store/unit_files_index.go
+++ b/store/unit_files_index.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/alecthomas/binary"
 
+	"sourcegraph.com/sourcegraph/srclib/util"
 	"sourcegraph.com/sourcegraph/srclib/store/phtable"
 	"sourcegraph.com/sourcegraph/srclib/unit"
 )
@@ -130,7 +131,7 @@ type filesToUnits map[string][]unit.ID2
 func (v filesToUnits) add(file string, u unit.ID2) {
 	file = path.Clean(file)
 	v[file] = append(v[file], u)
-	for _, dir := range ancestorDirsExceptRoot(file) {
+	for _, dir := range util.AncestorDirs(file, false) {
 		v.addIfNotExists(dir, u)
 	}
 }
@@ -144,25 +145,6 @@ func (v filesToUnits) addIfNotExists(dir string, u unit.ID2) {
 		}
 	}
 	v[dir] = append(v[dir], u)
-}
-
-// ancestorDirsExceptRoot returns a list of p's ancestor directories
-// excluding the root ("." or "/").
-func ancestorDirsExceptRoot(p string) []string {
-	if p == "" {
-		return nil
-	}
-	if len(p) == 1 && (p[0] == '.' || p[0] == '/') {
-		return nil
-	}
-
-	var dirs []string
-	for i, c := range p {
-		if c == '/' {
-			dirs = append(dirs, p[:i])
-		}
-	}
-	return dirs
 }
 
 // Write implements persistedIndex.

--- a/toolchain/find.go
+++ b/toolchain/find.go
@@ -79,10 +79,17 @@ func List() ([]*Info, error) {
 					return nil, err
 				}
 
-				// traverse symlinks but refer to symlinked trees' toolchains using
-				// the path to them through the original entry in SRCLIBPATH
-				dirs = append(dirs, path+string(filepath.Separator))
-				origDirs[path+string(filepath.Separator)] = dir
+				targetPath, err := os.Readlink(path)
+				if err != nil {
+					return nil, err
+				}
+
+				if _, traversed := origDirs[targetPath]; !traversed {
+					// traverse symlinks but refer to symlinked trees' toolchains using
+					// the path to them through the original entry in SRCLIBPATH
+					dirs = append(dirs, targetPath)
+					origDirs[targetPath], _ = filepath.Rel(dir, path)
+				}
 			} else if fi.Mode().IsDir() {
 				// Check for Srclibtoolchain file in this dir.
 
@@ -95,14 +102,18 @@ func List() ([]*Info, error) {
 				// Found a Srclibtoolchain file.
 				path = filepath.Clean(path)
 
-				var base string
+				var toolchainPath string
 				if orig, present := origDirs[dir]; present {
-					base = orig
+					toolchainPath, _ = filepath.Rel(dir, path)
+					if toolchainPath == "." {
+						toolchainPath = ""
+					}
+					toolchainPath = orig + toolchainPath
 				} else {
-					base = dir
+					toolchainPath, _ = filepath.Rel(dir, path)
 				}
-
-				toolchainPath, _ := filepath.Rel(base, path)
+				toolchainPath = filepath.ToSlash(toolchainPath)
+				
 
 				if otherDir, seen := seen[toolchainPath]; seen {
 					return nil, fmt.Errorf("saw 2 toolchains at path %s in dirs %s and %s", toolchainPath, otherDir, path)
@@ -136,15 +147,18 @@ func newInfo(toolchainPath, dir, configFile string) (*Info, error) {
 	prog := filepath.Join(".bin", filepath.Base(toolchainPath))
 
 	if runtime.GOOS == "windows" {
-		prog += ".exe"
+		prog = winExe(dir, prog)
 	}
 
-	if fi, err := os.Stat(filepath.Join(dir, prog)); os.IsNotExist(err) {
-		prog = ""
-	} else if err != nil {
-		return nil, err
-	} else if runtime.GOOS != "windows" && !(fi.Mode().Perm()&0111 > 0) {
-		return nil, fmt.Errorf("installed toolchain program %q is not executable (+x)", prog)
+	if runtime.GOOS != "windows" {
+		fi, err := os.Stat(filepath.Join(dir, prog))
+		if os.IsNotExist(err) {
+			prog = ""
+		} else {
+			if fi.Mode().Perm()&0111 == 0 {
+				return nil, fmt.Errorf("installed toolchain program %q is not executable (+x)", prog)
+			}
+		}
 	}
 
 	return &Info{
@@ -179,4 +193,21 @@ func lookInPaths(pattern string, paths string) ([]string, error) {
 	}
 	sort.Strings(found)
 	return found, nil
+}
+
+// searches for matching Windows executable (.exe, .bat, .cmd)
+func winExe(dir string, program string) (string) {
+	candidate := program + ".exe"
+	if _, err := os.Stat(filepath.Join(dir, candidate)); err == nil {
+		return candidate
+	}
+	candidate = program + ".bat"
+	if _, err := os.Stat(filepath.Join(dir, candidate)); err == nil {
+		return candidate
+	}
+	candidate = program + ".cmd"
+	if _, err := os.Stat(filepath.Join(dir, candidate)); err == nil {
+		return candidate
+	}
+	return ""
 }

--- a/toolchain/get.go
+++ b/toolchain/get.go
@@ -28,10 +28,13 @@ func Get(path string, update bool) (*Info, error) {
 		// older gits don't heed git https redirects, so manually substitute in
 		// the github.com clone url for sourcegraph.com clone urls
 		var substitutedPath string
-		if strings.HasPrefix(path, "sourcegraph.com/") {
-			substitutedPath = "github.com/" + strings.TrimPrefix(path, "sourcegraph.com/")
+		var uriPath string
+
+		uriPath = filepath.ToSlash(path)
+		if strings.HasPrefix(uriPath, "sourcegraph.com/") {
+			substitutedPath = "github.com/" + strings.TrimPrefix(uriPath, "sourcegraph.com/")
 		} else {
-			substitutedPath = path
+			substitutedPath = uriPath
 		}
 		cloneURL := "https://" + substitutedPath + ".git"
 		cmd := exec.Command("git", "clone", cloneURL, toolchainDir)

--- a/util/ancestordirs.go
+++ b/util/ancestordirs.go
@@ -15,13 +15,13 @@ func AncestorDirs(p string, self bool) []string {
 		return nil
 	}
 	var dirs []string
-	if self {
-		dirs = append(dirs, absPath)
-	}
 	dir := filepath.Dir(absPath)
 	for dir != "." && dir[len(dir)-1:] != string(filepath.Separator) {
-		dirs = append(dirs, dir)
+		dirs = append([]string{dir}, dirs...)
 		dir = filepath.Dir(dir)
+	}
+	if self {
+		dirs = append(dirs, absPath)
 	}
 	return dirs
 }

--- a/util/ancestordirs.go
+++ b/util/ancestordirs.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+	"path/filepath"
+)
+
+// AncestorDirs returns a list of p's ancestor
+// directories (optionally including itself) excluding the root ("." or "/")).
+func AncestorDirs(p string, self bool) []string {
+	if p == "" {
+		return nil
+	}
+	absPath, err := filepath.Abs(p)
+	if (err != nil) {
+		return nil
+	}
+	var dirs []string
+	if self {
+		dirs = append(dirs, absPath)
+	}
+	dir := filepath.Dir(absPath)
+	for dir != "." && dir[len(dir)-1:] != string(filepath.Separator) {
+		dirs = append(dirs, dir)
+		dir = filepath.Dir(dir)
+	}
+	return dirs
+}
+


### PR DESCRIPTION
- added support for Windows-style command line flags produced by go-flags (/NAME)
- "toolchain add" - making default directory name "." (otherwise absolute path resolution fails)
- looking for toolchain.exe, toolchain.bat, toolchain.cmd executables
- fixed endless "toolchain list"
- fixed "toolchain get" on Windows (because of different separator char URI substitution failed)
- "test" ignores white spaces when doing diff
- fixed VCS resolution - forcing slashes to be used as directory separators in generated makefile
