### PR TITLE
store: In memory cache for IndexedTreeStore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /release/
 
 /.tmp-selfupdate/
+
+*.test

--- a/store/fs_store.go
+++ b/store/fs_store.go
@@ -255,7 +255,8 @@ func (s *fsRepoStore) treeStoreFS(commitID string) rwvfs.FileSystem {
 func (s *fsRepoStore) newTreeStore(commitID string) TreeStoreImporter {
 	fs := s.treeStoreFS(commitID)
 	if useIndexedStore {
-		return newIndexedTreeStore(fs)
+		cacheKey := fs.String()
+		return newIndexedTreeStore(fs, cacheKey)
 	}
 	return newFSTreeStore(fs)
 }

--- a/store/index_cache.go
+++ b/store/index_cache.go
@@ -1,0 +1,83 @@
+package store
+
+import "sync"
+
+// cacheableIndexStore is an index store which can allow the indexes to be
+// shared across instances of the store. The store itself needs to be
+// instrumented with calls to `cacheGet` and `cachePut`
+type cacheableIndexStore interface {
+	StoreKey() interface{}
+}
+
+// indexCacheKey is used to uniquely identify a (store, index) pair.
+type indexCacheKey struct {
+	// storeKey is a string or struct to uniquely identify a
+	// store. Usually this is just a URI or path to the underlying store
+	storeKey  interface{}
+	indexName string
+}
+
+// indexCache stores indexes for use across stores. This is to prevent the
+// cost of deserializing the index from the underlying VFS store
+type indexCache struct {
+	indexes map[indexCacheKey]Index
+	sync.RWMutex
+}
+
+var defaultIndexCache *indexCache = &indexCache{
+	indexes: map[indexCacheKey]Index{},
+}
+
+// cacheGet attempts to fetch an instance of a loaded Index from an in-memory
+// cache. If it fails, it will return the fallback index.
+//
+// Note: Their may be multiple goroutines reading from the Index
+// concurrently. Pleasue ensure all uses of the Index are read-only to prevent
+// concurrency issues.
+func cacheGet(store cacheableIndexStore, name string, fallback Index) Index {
+	return defaultIndexCache.cacheGet(store, name, fallback)
+}
+
+// cachePut will store an index in the cache
+func cachePut(store cacheableIndexStore, name string, index Index) {
+	defaultIndexCache.cachePut(store, name, index)
+}
+
+func (c *indexCache) cacheGet(store cacheableIndexStore, name string, fallback Index) Index {
+	c.RLock()
+	defer c.RUnlock()
+	key := indexCacheKey{
+		storeKey:  store.StoreKey(),
+		indexName: name,
+	}
+	if index, ok := c.indexes[key]; ok {
+		vlog.Printf("%s: loaded from cache key=%v", name, key)
+		return index
+	} else {
+		vlog.Printf("%s: not in cache key=%v", name, key)
+		return fallback
+	}
+}
+
+func (c *indexCache) cachePut(store cacheableIndexStore, name string, index Index) {
+	key := indexCacheKey{
+		storeKey:  store.StoreKey(),
+		indexName: name,
+	}
+
+	// We don't need to store something in the cache that is already
+	// stored
+	c.RLock()
+	if _, ok := c.indexes[key]; ok {
+		// NOP we already have it cached
+		c.RUnlock()
+		return
+	}
+	c.RUnlock()
+
+	vlog.Printf("%s: updating cache key=%v", name, key)
+	// Update cache
+	c.Lock()
+	defer c.Unlock()
+	c.indexes[key] = index
+}

--- a/store/index_cache_test.go
+++ b/store/index_cache_test.go
@@ -1,0 +1,41 @@
+package store
+
+import "testing"
+
+type mockCacheableIndexStore struct{}
+
+func (m *mockCacheableIndexStore) StoreKey() interface{} { return "test" }
+
+type mockIndex struct {
+	id int
+}
+
+func (m *mockIndex) Ready() bool              { return true }
+func (m *mockIndex) Covers(f interface{}) int { return 1 }
+
+func TestCache(t *testing.T) {
+	store := &mockCacheableIndexStore{}
+	index1 := &mockIndex{123}
+	index2 := &mockIndex{456}
+
+	// empty cache, should use fallback
+	if index1 != cacheGet(store, "test_index", index1) {
+		t.Errorf("cacheGet expected to use fallback value")
+	}
+
+	// We put in 2, and get with fallback 1. We should get back 2
+	cachePut(store, "test_index", index2)
+	if index2 != cacheGet(store, "test_index", index1) {
+		t.Errorf("cachePut followed by cacheGet returns different results")
+	}
+
+	// Same test, but on different key with indexes swapped
+	if index2 != cacheGet(store, "test_index_2", index2) {
+		t.Errorf("cacheGet expected to use fallback value")
+	}
+	cachePut(store, "test_index_2", index1)
+	if index1 != cacheGet(store, "test_index_2", index2) {
+		t.Errorf("cachePut followed by cacheGet returns different results")
+	}
+
+}

--- a/store/indexed_test.go
+++ b/store/indexed_test.go
@@ -12,7 +12,7 @@ func TestIndexedUnitStore(t *testing.T) {
 func TestIndexedTreeStore(t *testing.T) {
 	useIndexedStore = true
 	testTreeStore(t, func() TreeStoreImporter {
-		return newIndexedTreeStore(newTestFS())
+		return newIndexedTreeStore(newTestFS(), "test")
 	})
 }
 


### PR DESCRIPTION
IndexedTreeStore contains a few indexes used by most queries. In some repos these can be large and the time to read, gunzip and unmarshal can be costly. This commit adds a simple in-memory cache around the indexes. The places where we `get` and `put` from the cache are only done where the index is read only, so we do not have to concern ourselves with making the Indexes handle concurrent writes.

In a synthetic repo on my MBA some queries took 6s, most of that time was dominated by loading indexes in `IndexedTreeStore`. In particular I generated a repo with

```bash
$ srclib gen-data urefs -v -u 500 -f 10 -r 'tmp/genrepo11' --ndefs 10 --gen-source
```

then did the `ListExamples` operation in sourcegraph.
