### PR TITLE
cli: do not skip installation of toolchains

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ install:
 
 script:
   - go test -v ./...
-  - make install-std-toolchains
-  - make test-std-toolchains
+  - make install-all-toolchains
+  - make test-all-toolchains
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MAKEFLAGS+=--no-print-directory
 
-.PHONY: default install srclib release upload-release check-release install-std-toolchains test-std-toolchains
+.PHONY: default install srclib release upload-release check-release install-all-toolchains test-all-toolchains
 
 default: install
 
@@ -33,12 +33,12 @@ check-release:
 	echo; echo
 	@echo Released srclib $(V)
 
-install-std-toolchains:
+install-all-toolchains:
 	srclib toolchain install go python ruby javascript java
 
 toolchains ?= go javascript python ruby
 
-test-std-toolchains:
+test-all-toolchains:
 	@echo Checking that all standard toolchains are installed
 	for lang in $(toolchains); do echo $$lang; srclib toolchain list | grep srclib-$$lang; done
 
@@ -47,5 +47,5 @@ test-std-toolchains:
 	@echo Testing installation of standard toolchains in Docker if Docker is running
 	(docker info && make -C integration test) || echo Docker is not running...skipping integration tests.
 
-regen-std-toolchain-tests:
+regen-all-toolchain-tests:
 	for lang in $(toolchains); do echo $$lang; cd ~/.srclib/sourcegraph.com/sourcegraph/srclib-$$lang; srclib test --gen; done

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ check-release:
 	@echo Released srclib $(V)
 
 install-std-toolchains:
-	srclib toolchain install-std
+	srclib toolchain go python ruby javascript java
 
 toolchains ?= go javascript python ruby
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ check-release:
 	@echo Released srclib $(V)
 
 install-std-toolchains:
-	srclib toolchain go python ruby javascript java
+	srclib toolchain install go python ruby javascript java
 
 toolchains ?= go javascript python ruby
 

--- a/cli/toolchain_cmd.go
+++ b/cli/toolchain_cmd.go
@@ -469,7 +469,7 @@ func installRubyToolchain() error {
 	srclibpathDir := filepath.Join(strings.Split(srclib.Path, ":")[0], toolchain) // toolchain dir under SRCLIBPATH
 
 	if _, err := exec.LookPath("ruby"); isExecErrNotFound(err) {
-		return errors.New("no `ruby` in PATH (assuming you don't have Ruby installed and you don't want the Ruby toolchain)")
+		return errors.New("no `ruby` in PATH (do you have Ruby installed properly?)")
 	}
 	if _, err := exec.LookPath("bundle"); isExecErrNotFound(err) {
 		return fmt.Errorf("found `ruby` in PATH but did not find `bundle` in PATH; Ruby toolchain requires bundler (run `gem install bundler` to install it)")
@@ -494,7 +494,7 @@ func installJavaScriptToolchain() error {
 	srclibpathDir := filepath.Join(strings.Split(srclib.Path, ":")[0], toolchain) // toolchain dir under SRCLIBPATH
 
 	if _, err := exec.LookPath("node"); isExecErrNotFound(err) {
-		return errors.New("no `node` in PATH (assuming you don't have Node.js installed and you don't want the JavaScript toolchain)")
+		return errors.New("no `node` in PATH (do you have Node.js installed properly?)")
 	}
 	if _, err := exec.LookPath("npm"); isExecErrNotFound(err) {
 		return fmt.Errorf("no `npm` in PATH; JavaScript toolchain requires npm")

--- a/cli/toolchain_cmd.go
+++ b/cli/toolchain_cmd.go
@@ -437,7 +437,7 @@ func installGoToolchain() error {
 		return errors.New(`
 Refusing to install Go toolchain because there is no GOPATH environment variable
 set.
-Note: Please ensure that Go 1.4+ is installed and that $GOPATH is set.`)
+Note: Please ensure that Go 1.4+ is installed (see https://golang.org/doc/install) and that $GOPATH is set.`)
 	}
 
 	srclibpathDir := filepath.Join(strings.Split(srclib.Path, ":")[0], toolchain) // toolchain dir under SRCLIBPATH

--- a/cli/toolchain_cmd.go
+++ b/cli/toolchain_cmd.go
@@ -105,15 +105,6 @@ func init() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	_, err = c.AddCommand("install-std",
-		"install standard toolchains",
-		"Install standard toolchains (sourcegraph.com/sourcegraph/srclib-* toolchains).",
-		&toolchainInstallStdCmd,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
 }
 
 type ToolchainPath string
@@ -439,30 +430,6 @@ func installToolchains(langs []toolchainInstaller) error {
 	return nil
 }
 
-type ToolchainInstallStdCmd struct {
-	Skip []string `long:"skip" description:"skip installing matching toolchains (can be specified multiple times; e.g., --skip go --skip ruby)" value-name:"NAME"`
-}
-
-var toolchainInstallStdCmd ToolchainInstallStdCmd
-
-func (c *ToolchainInstallStdCmd) Execute(args []string) error {
-	fmt.Println(brush.Cyan("Installing/upgrading standard toolchains..."))
-	fmt.Println()
-
-	var is []toolchainInstaller
-OuterLoop:
-	for name, installer := range stdToolchains {
-		for _, skip := range c.Skip {
-			if strings.EqualFold(name, skip) {
-				fmt.Println(brush.Yellow(fmt.Sprintf("Skipping installation of %s", installer.name)))
-				continue OuterLoop
-			}
-		}
-		is = append(is, installer)
-	}
-	return installToolchains(is)
-}
-
 func installGoToolchain() error {
 	const toolchain = "sourcegraph.com/sourcegraph/srclib-go"
 	gopath := os.Getenv("GOPATH")
@@ -515,7 +482,7 @@ func installRubyToolchain() error {
 
 	log.Println("Installing deps for Ruby toolchain in", srclibpathDir)
 	if err := execCmd("make", "-C", srclibpathDir); err != nil {
-		return fmt.Errorf("%s\n\nTip: If you are using a version of Ruby other than 2.1.2 (the default for srclib), or if you are using your system Ruby, try using a Ruby version manager (such as https://rvm.io) to install a more standard Ruby, and try Ruby 2.1.2.\n\nIf you are still having problems, post an issue at https://github.com/sourcegraph/srclib-ruby/issues with the full log output and information about your OS and Ruby version.\n\nIf you don't care about Ruby, skip this installation by running `srclib toolchain install-std --skip ruby`.", err)
+		return fmt.Errorf("%s\n\nTip: If you are using a version of Ruby other than 2.1.2 (the default for srclib), or if you are using your system Ruby, try using a Ruby version manager (such as https://rvm.io) to install a more standard Ruby, and try Ruby 2.1.2.\n\nIf you are still having problems, post an issue at https://github.com/sourcegraph/srclib-ruby/issues with the full log output and information about your OS and Ruby version.\n\n`.", err)
 	}
 
 	return nil

--- a/docs/sources/install.md
+++ b/docs/sources/install.md
@@ -64,21 +64,12 @@ go get -u -v sourcegraph.com/sourcegraph/srclib/cmd/srclib
 
 ##Language Toolchains
 
-###Standard set
-To install the standard set of language analysis toolchains
+To install the language analysis toolchains for
 ([Go](toolchains/go.md), [Ruby](toolchains/ruby.md),
 [JavaScript](toolchains/javascript.md), and [Python](toolchains/python.md)), run:
 
 ```
-srclib toolchain install-std
-```
-By default this installs the toolchains for Ruby, Go, JavaScript, and Python.
-
-###Selective installation
-To skip installing toolchains you don't care about, use `--skip`, as in
-
-```
-srclib toolchain install-std --skip javascript --skip ruby
+srclib toolchain go ruby javascript python
 ```
 
 If this command fails, please

--- a/docs/sources/install.md
+++ b/docs/sources/install.md
@@ -69,7 +69,7 @@ To install the language analysis toolchains for
 [JavaScript](toolchains/javascript.md), and [Python](toolchains/python.md)), run:
 
 ```
-srclib toolchain go ruby javascript python
+srclib toolchain install go ruby javascript python
 ```
 
 If this command fails, please

--- a/docs/theme/home.html
+++ b/docs/theme/home.html
@@ -68,7 +68,7 @@
 
         <h2>2. Install toolchains</h2>
         <p>Toolchains add support for languages (JavaScript, Ruby, Go, etc.).</p>
-        <p><a href="/gettingstarted">Install the standard set of toolchains</a>: <code>src toolchain go ruby javascript python</code></p>
+        <p><a href="/gettingstarted">Install the standard set of toolchains</a>: <code>src toolchain install go ruby javascript python</code></p>
         <p>You can skip languages you don't want by adding, e.g., <code>--skip ruby</code>.</p>
         <p>To list installed toolchains, run <code>src toolchain list</code>.</p>
 

--- a/docs/theme/home.html
+++ b/docs/theme/home.html
@@ -68,7 +68,7 @@
 
         <h2>2. Install toolchains</h2>
         <p>Toolchains add support for languages (JavaScript, Ruby, Go, etc.).</p>
-        <p><a href="/gettingstarted">Install the standard set of toolchains</a>: <code>src toolchain install-std</code></p>
+        <p><a href="/gettingstarted">Install the standard set of toolchains</a>: <code>src toolchain go ruby javascript python</code></p>
         <p>You can skip languages you don't want by adding, e.g., <code>--skip ruby</code>.</p>
         <p>To list installed toolchains, run <code>src toolchain list</code>.</p>
 

--- a/docs/theme/home.html
+++ b/docs/theme/home.html
@@ -69,7 +69,6 @@
         <h2>2. Install toolchains</h2>
         <p>Toolchains add support for languages (JavaScript, Ruby, Go, etc.).</p>
         <p><a href="/gettingstarted">Install the standard set of toolchains</a>: <code>src toolchain install go ruby javascript python</code></p>
-        <p>You can skip languages you don't want by adding, e.g., <code>--skip ruby</code>.</p>
         <p>To list installed toolchains, run <code>src toolchain list</code>.</p>
 
         <h2>3. Install an editor plugin</h2>

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -44,4 +44,4 @@ RUN chown -R srclib /usr/local/rvm
 ADD ./srclib /usr/local/bin/srclib
 USER srclib
 
-RUN srclib toolchain go python ruby javascript java
+RUN srclib toolchain install go python ruby javascript java

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -44,4 +44,4 @@ RUN chown -R srclib /usr/local/rvm
 ADD ./srclib /usr/local/bin/srclib
 USER srclib
 
-RUN srclib toolchain install-std
+RUN srclib toolchain go python ruby javascript java


### PR DESCRIPTION
Instead, error out right away when they fail. If someone runs `srclib toolchain install-std`
then they expect every toolchain to be installed, not for some to be skipped
(the user may potentially miss the error among all the log output). Likewise if
the user wants to explicitly install a given toolchain (e.g. `srclib toolchain install go`)
they do not want it to skip installation due to an error.

For example, trying to install the Go toolchain without $GOPATH set now produces:

```
$ srclib toolchain install go
Go (sourcegraph.com/sourcegraph/srclib-go) ====================================
failed to install/upgrade Go (sourcegraph.com/sourcegraph/srclib-go) toolchain:
Refusing to install Go toolchain because there is no GOPATH environment variable
set.
Note: Please ensure that Go 1.4+ is installed and that $GOPATH is set.

FAILED: srclib toolchain install go
```

Instead of:

```
skipped sourcegraph.com/sourcegraph/srclib-go: no GOPATH set (assuming Go is not installed and you don't want the Go toolchain)
```

Which is rather confusing given that I said `srclib toolchain install go`, so why is it assuming that I don't want the Go toolchain? I explicitly asked for it.