### PR TITLE
store.defQueryTreeIndex: Prevent possible nil pointer dereference panic.

### DIFF
--- a/store/def_query_tree_index.go
+++ b/store/def_query_tree_index.go
@@ -43,6 +43,11 @@ func (x *defQueryTreeIndex) getByQuery(q string) (map[unit.ID2]byteOffsets, bool
 		panic("mafsaTable not built/read")
 	}
 
+	if x.mt.t == nil {
+		vlog.Println("getByQuery: x.mt.t == nil")
+		return nil, false
+	}
+
 	q = strings.ToLower(q)
 	node, i := x.mt.t.IndexedTraverse([]rune(q))
 	if node == nil {


### PR DESCRIPTION
There are situations where `x.mt.t` is nil, so doing `node, i := x.mt.t.IndexedTraverse([]rune(q))` results in a nil pointer dereference panic.

This is a quick fix to prevent a panic. A proper fix will be to avoid calling `getByQuery` when the mafsaTable is not built/read.