### PR TITLE
Make `srclib toolchain install go` actually install Go if it can.

### DIFF
--- a/cli/toolchain_cmd.go
+++ b/cli/toolchain_cmd.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"path/filepath"
 	"time"
+	"go/build"
 
 	"strings"
 	"sync"
@@ -466,9 +467,11 @@ func installGo() error {
 		}
 
 		err := cmds(
+			// install add-apt-repository, which is needed on Ubuntu.
+			[]string{"sudo", "apt-get", "install", "-y", "software-properties-common"}
 			[]string{"sudo", "add-apt-repository", "-y", "ppa:evarlast/golang1.5"},
 			[]string{"sudo", "apt-get", "-y", "update"},
-			[]string{"sudo", "apt-get", "install", "-y", "golang-go"},
+			[]string{"sudo", "apt-get", "install", "-y", "golang-go-linux-" + build.DefaultContext.GOARCH},
 		)
 		if err != nil {
 			return fmt.Errorf(goInstallErrorMessage, err)

--- a/cli/toolchain_cmd.go
+++ b/cli/toolchain_cmd.go
@@ -471,7 +471,7 @@ func installGo() error {
 			[]string{"sudo", "apt-get", "install", "-y", "software-properties-common"},
 			[]string{"sudo", "add-apt-repository", "-y", "ppa:evarlast/golang1.5"},
 			[]string{"sudo", "apt-get", "-y", "update"},
-			[]string{"sudo", "apt-get", "install", "-y", "golang-go-linux-" + build.DefaultContext.GOARCH},
+			[]string{"sudo", "apt-get", "install", "-y", "golang-go-linux-" + build.Default.GOARCH},
 		)
 		if err != nil {
 			return fmt.Errorf(goInstallErrorMessage, err)

--- a/cli/toolchain_cmd.go
+++ b/cli/toolchain_cmd.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"go/build"
 	"io"
 	"io/ioutil"
 	"log"
@@ -13,14 +14,13 @@ import (
 	"path"
 	"path/filepath"
 	"time"
-	"go/build"
 
 	"strings"
 	"sync"
 
-	"github.com/GeertJohan/go.ask"
+	ask "github.com/GeertJohan/go.ask"
 	"github.com/aybabtme/color/brush"
-	"sourcegraph.com/sourcegraph/go-flags"
+	flags "sourcegraph.com/sourcegraph/go-flags"
 	"sourcegraph.com/sourcegraph/srclib"
 	"sourcegraph.com/sourcegraph/srclib/toolchain"
 )
@@ -468,7 +468,7 @@ func installGo() error {
 
 		err := cmds(
 			// install add-apt-repository, which is needed on Ubuntu.
-			[]string{"sudo", "apt-get", "install", "-y", "software-properties-common"}
+			[]string{"sudo", "apt-get", "install", "-y", "software-properties-common"},
 			[]string{"sudo", "add-apt-repository", "-y", "ppa:evarlast/golang1.5"},
 			[]string{"sudo", "apt-get", "-y", "update"},
 			[]string{"sudo", "apt-get", "install", "-y", "golang-go-linux-" + build.DefaultContext.GOARCH},


### PR DESCRIPTION
This PR automatically installs Go itself if it is not already installed. Note that:

 - The user is prompted for "Do you want to install Go via <your_platform_method>? [y/n]:" otherwise installation aborts.
 - On Linux, it assumes that `apt-get` is available. If it is not, installation aborts.
 - On OS X, it assumes that `brew` is available. If it is not, installation aborts.

I've tested the command sets on both Ubuntu 14.04 and OS X.