### PR TITLE
proto: re-generate protobufs with latest gogo/protobuf

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -32,19 +32,22 @@
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/proto",
-			"Rev": "4d9351c7a8a1bee7c5b0d86e40a15c55be0ee930"
+			"Comment": "v0.1-58-g2008751",
+			"Rev": "200875106f3bf0eb01eb297dae30b250a25ffc84"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/protoc-gen-gogo/descriptor",
-			"Rev": "4d9351c7a8a1bee7c5b0d86e40a15c55be0ee930"
+			"Comment": "v0.1-58-g2008751",
+			"Rev": "200875106f3bf0eb01eb297dae30b250a25ffc84"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/test",
-			"Rev": "4d9351c7a8a1bee7c5b0d86e40a15c55be0ee930"
+			"Comment": "v0.1-58-g2008751",
+			"Rev": "200875106f3bf0eb01eb297dae30b250a25ffc84"
 		},
 		{
 			"ImportPath": "github.com/golang/protobuf/proto",
-			"Rev": "efd7476481382c195beb33acd8ec2f1527167fb4"
+			"Rev": "3d2510a4dd961caffa2ae781669c628d82db700a"
 		},
 		{
 			"ImportPath": "github.com/kardianos/osext",
@@ -105,7 +108,7 @@
 		},
 		{
 			"ImportPath": "golang.org/x/oauth2",
-			"Rev": "b5adcc2dcdf009d0391547edc6ecbaff889f5bb9"
+			"Rev": "2fbf3d7329d847b125188ad64b68cfb1f548938a"
 		},
 		{
 			"ImportPath": "golang.org/x/tools/godoc/vfs",
@@ -121,9 +124,9 @@
 		},
 		{
 			"ImportPath": "google.golang.org/grpc",
-			"Rev": "91c8b79535eb6045d70ec671d302213f88a3ab95"
+			"Rev": "f7d1653e300d6ad9f019bce7a5f5ab3b4821f637"
 		},
-		{			
+		{
 			"ImportPath": "github.com/inconshreveable/go-update",
 			"Rev": "68f5725818189545231c1fd8694793d45f2fc529"
 		},

--- a/ann/ann.pb.go
+++ b/ann/ann.pb.go
@@ -14,13 +14,17 @@ It has these top-level messages:
 package ann
 
 import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
+import math "math"
 
-// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto"
 
 import sourcegraph_com_sqs_pbtypes "sourcegraph.com/sqs/pbtypes"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
+var _ = fmt.Errorf
+var _ = math.Inf
 
 // An Ann is a source code annotation.
 //
@@ -58,6 +62,3 @@ type Ann struct {
 func (m *Ann) Reset()         { *m = Ann{} }
 func (m *Ann) String() string { return proto.CompactTextString(m) }
 func (*Ann) ProtoMessage()    {}
-
-func init() {
-}

--- a/graph/def.pb.go
+++ b/graph/def.pb.go
@@ -17,17 +17,25 @@ It has these top-level messages:
 	DefDoc
 	DefFormatStrings
 	QualFormatStrings
+	Doc
+	Output
+	Ref
+	RefDefKey
 */
 package graph
 
 import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
+import math "math"
 
-// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto"
 
 import sourcegraph_com_sqs_pbtypes "sourcegraph.com/sqs/pbtypes"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
+var _ = fmt.Errorf
+var _ = math.Inf
 
 // DefKey specifies a definition, either concretely or abstractly. A concrete
 // definition key has a non-empty CommitID and refers to a definition defined in a
@@ -166,6 +174,3 @@ type QualFormatStrings struct {
 func (m *QualFormatStrings) Reset()         { *m = QualFormatStrings{} }
 func (m *QualFormatStrings) String() string { return proto.CompactTextString(m) }
 func (*QualFormatStrings) ProtoMessage()    {}
-
-func init() {
-}

--- a/graph/doc.pb.go
+++ b/graph/doc.pb.go
@@ -5,11 +5,15 @@
 package graph
 
 import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
+import math "math"
 
-// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
+var _ = fmt.Errorf
+var _ = math.Inf
 
 // Doc is documentation on a Def.
 type Doc struct {
@@ -32,6 +36,3 @@ type Doc struct {
 func (m *Doc) Reset()         { *m = Doc{} }
 func (m *Doc) String() string { return proto.CompactTextString(m) }
 func (*Doc) ProtoMessage()    {}
-
-func init() {
-}

--- a/graph/output.pb.go
+++ b/graph/output.pb.go
@@ -5,12 +5,16 @@
 package graph
 
 import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
+import math "math"
 
-// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto"
 import ann "sourcegraph.com/sourcegraph/srclib/ann"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
+var _ = fmt.Errorf
+var _ = math.Inf
 
 type Output struct {
 	Defs []*Def     `protobuf:"bytes,1,rep,name=defs" json:"Defs,omitempty"`
@@ -22,6 +26,3 @@ type Output struct {
 func (m *Output) Reset()         { *m = Output{} }
 func (m *Output) String() string { return proto.CompactTextString(m) }
 func (*Output) ProtoMessage()    {}
-
-func init() {
-}

--- a/graph/ref.pb.go
+++ b/graph/ref.pb.go
@@ -5,11 +5,15 @@
 package graph
 
 import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
+import math "math"
 
-// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
+var _ = fmt.Errorf
+var _ = math.Inf
 
 // Ref represents a reference from source code to a Def.
 type Ref struct {
@@ -57,6 +61,3 @@ type RefDefKey struct {
 func (m *RefDefKey) Reset()         { *m = RefDefKey{} }
 func (m *RefDefKey) String() string { return proto.CompactTextString(m) }
 func (*RefDefKey) ProtoMessage()    {}
-
-func init() {
-}

--- a/store/pb/srcstore.pb.go
+++ b/store/pb/srcstore.pb.go
@@ -15,8 +15,10 @@ It has these top-level messages:
 package pb
 
 import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
+import math "math"
 
-// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto"
 import unit "sourcegraph.com/sourcegraph/srclib/unit"
 import graph3 "sourcegraph.com/sourcegraph/srclib/graph"
 import pbtypes "sourcegraph.com/sqs/pbtypes"
@@ -27,11 +29,9 @@ import (
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ context.Context
-var _ grpc.ClientConn
-
-// Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
+var _ = fmt.Errorf
+var _ = math.Inf
 
 type ImportOp struct {
 	Repo     string               `protobuf:"bytes,1,opt,name=repo,proto3" json:"repo,omitempty"`
@@ -53,8 +53,9 @@ func (m *IndexOp) Reset()         { *m = IndexOp{} }
 func (m *IndexOp) String() string { return proto.CompactTextString(m) }
 func (*IndexOp) ProtoMessage()    {}
 
-func init() {
-}
+// Reference imports to suppress errors if they are not otherwise used.
+var _ context.Context
+var _ grpc.ClientConn
 
 // Client API for MultiRepoImporter service
 
@@ -106,9 +107,9 @@ func RegisterMultiRepoImporterServer(s *grpc.Server, srv MultiRepoImporterServer
 	s.RegisterService(&_MultiRepoImporter_serviceDesc, srv)
 }
 
-func _MultiRepoImporter_Import_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
+func _MultiRepoImporter_Import_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
 	in := new(ImportOp)
-	if err := codec.Unmarshal(buf, in); err != nil {
+	if err := dec(in); err != nil {
 		return nil, err
 	}
 	out, err := srv.(MultiRepoImporterServer).Import(ctx, in)
@@ -118,9 +119,9 @@ func _MultiRepoImporter_Import_Handler(srv interface{}, ctx context.Context, cod
 	return out, nil
 }
 
-func _MultiRepoImporter_Index_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
+func _MultiRepoImporter_Index_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
 	in := new(IndexOp)
-	if err := codec.Unmarshal(buf, in); err != nil {
+	if err := dec(in); err != nil {
 		return nil, err
 	}
 	out, err := srv.(MultiRepoImporterServer).Index(ctx, in)

--- a/unit/unit.pb.go
+++ b/unit/unit.pb.go
@@ -14,11 +14,15 @@ It has these top-level messages:
 package unit
 
 import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
+import math "math"
 
-// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
+var _ = fmt.Errorf
+var _ = math.Inf
 
 // A RepoSourceUnit is the "concrete" form of SourceUnit that includes
 // information about which repository (and commit) the source unit
@@ -38,6 +42,3 @@ type RepoSourceUnit struct {
 func (m *RepoSourceUnit) Reset()         { *m = RepoSourceUnit{} }
 func (m *RepoSourceUnit) String() string { return proto.CompactTextString(m) }
 func (*RepoSourceUnit) ProtoMessage()    {}
-
-func init() {
-}


### PR DESCRIPTION
Updated github.com/gogo/protobuf to commit `200875` and did `go generate ./...`