### PR TITLE
Fixed behavior in sgx mode; updated go-flags; converting char offsets to byte ones

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -129,8 +129,7 @@
 		},
 		{
 			"ImportPath": "sourcegraph.com/sourcegraph/go-flags",
-			"Comment": "v1-295-gac1de6d",
-			"Rev": "ac1de6df8e99179055302900918093c0443d3f7a"
+			"Rev": "7c86b1bed79b1dd42ee6650b6789776c40f78e12"
 		},
 		{
 			"ImportPath": "sourcegraph.com/sourcegraph/makex",

--- a/dep/rule.go
+++ b/dep/rule.go
@@ -12,6 +12,7 @@ import (
 	"sourcegraph.com/sourcegraph/srclib/plan"
 	"sourcegraph.com/sourcegraph/srclib/toolchain"
 	"sourcegraph.com/sourcegraph/srclib/unit"
+	"sourcegraph.com/sourcegraph/srclib/util"
 )
 
 const depresolveOp = "depresolve"
@@ -59,7 +60,7 @@ func (r *ResolveDepsRule) Prereqs() []string {
 
 func (r *ResolveDepsRule) Recipes() []string {
 	return []string{
-		fmt.Sprintf("%s tool %s %q %q < $^ 1> $@", srclib.CommandName, r.opt.ToolchainExecOpt, r.Tool.Toolchain, r.Tool.Subcmd),
+		fmt.Sprintf("%s tool %s %q %q < $^ 1> $@", util.SafeCommandName(srclib.CommandName), r.opt.ToolchainExecOpt, r.Tool.Toolchain, r.Tool.Subcmd),
 	}
 }
 

--- a/flagutil/marshal.go
+++ b/flagutil/marshal.go
@@ -3,7 +3,6 @@ package flagutil
 import (
 	"fmt"
 	"reflect"
-	"runtime"
 	"strings"
 
 	"sourcegraph.com/sourcegraph/go-flags"
@@ -28,10 +27,6 @@ func marshalArgsInGroup(group *flags.Group, prefix string) ([]string, error) {
 		// handle flags with both short and long (just get the long)
 		if i := strings.Index(flagStr, ", --"); i != -1 {
 			flagStr = flagStr[i+2:]
-		} else if runtime.GOOS == "windows" {
-			if i := strings.Index(flagStr, ", /"); i != -1 {
-				flagStr = flagStr[i+2:]
-			}
 		}
 
 		switch v := opt.Value().(type) {

--- a/flagutil/marshal_test.go
+++ b/flagutil/marshal_test.go
@@ -2,8 +2,6 @@ package flagutil
 
 import (
 	"reflect"
-	"runtime"
-	"strings"
 	"testing"
 )
 
@@ -106,18 +104,6 @@ func TestMarshalArgs(t *testing.T) {
 			continue
 		}
 
-		if runtime.GOOS == "windows" && test.wantArgs != nil {
-			tmp := make([]string, 0, len(test.wantArgs))
-			for _, arg := range test.wantArgs {
-				if strings.HasPrefix(arg, "--") {
-					arg = "/" + string(arg[2:])
-				} else if strings.HasPrefix(arg, "-") {
-					arg = "/" + string(arg[1:])
-				}
-				tmp = append(tmp, arg)
-			}
-			test.wantArgs = tmp
-		}
 		if !reflect.DeepEqual(args, test.wantArgs) {
 			t.Errorf("got args %v, want %v", args, test.wantArgs)
 		}

--- a/grapher/grapher.go
+++ b/grapher/grapher.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/sqs/fileset"
 
@@ -106,7 +105,7 @@ func NormalizeData(currentRepoURI, unitType, dir string, o *graph.Output) error 
 		}
 	}
 
-	if unitType != "GoPackage" && unitType != "Dockerfile" && !strings.HasPrefix(unitType, "Java") && unitType != "NugetPackage" {
+	if unitType != "GoPackage" && unitType != "Dockerfile" && unitType != "NugetPackage" {
 		ensureOffsetsAreByteOffsets(dir, o)
 	}
 

--- a/grapher/rule.go
+++ b/grapher/rule.go
@@ -13,6 +13,7 @@ import (
 	"sourcegraph.com/sourcegraph/srclib/plan"
 	"sourcegraph.com/sourcegraph/srclib/toolchain"
 	"sourcegraph.com/sourcegraph/srclib/unit"
+	"sourcegraph.com/sourcegraph/srclib/util"
 )
 
 const graphOp = "graph"
@@ -62,8 +63,9 @@ func (r *GraphUnitRule) Prereqs() []string {
 }
 
 func (r *GraphUnitRule) Recipes() []string {
+	safeCommand := util.SafeCommandName(srclib.CommandName)
 	return []string{
-		fmt.Sprintf("%s tool %s %q %q < $< | %s internal normalize-graph-data --unit-type %q --dir . 1> $@", srclib.CommandName, r.opt.ToolchainExecOpt, r.Tool.Toolchain, r.Tool.Subcmd, srclib.CommandName, r.Unit.Type),
+		fmt.Sprintf("%s tool %s %q %q < $< | %s internal normalize-graph-data --unit-type %q --dir . 1> $@", safeCommand, r.opt.ToolchainExecOpt, r.Tool.Toolchain, r.Tool.Subcmd, safeCommand, r.Unit.Type),
 	}
 }
 

--- a/util/makefile.go
+++ b/util/makefile.go
@@ -1,0 +1,8 @@
+package util
+
+// Makes command name safe for shell script (and for makefiles).
+// For example, Cygwin does not like when you trying to execute C:/foo/bar.exe arguments
+// so we replacing first : with \: there. On Unix/Darwin there is no need to perform replacements
+func SafeCommandName(command string) string {
+	return safeCommandName(command)
+}

--- a/util/makefile_other.go
+++ b/util/makefile_other.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package util
+
+func safeCommandName(command string) string {
+	return command
+}

--- a/util/makefile_windows.go
+++ b/util/makefile_windows.go
@@ -1,0 +1,12 @@
+// +build windows
+
+package util
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+func safeCommandName(command string) string {
+	return strings.Replace(filepath.ToSlash(command), ":", "\\:", 1)
+}


### PR DESCRIPTION
- When running srclib in sgx environment, command name on Windows looks like "C:/foo/src.exe srclib". Cygwin environment does not handle propely case when command name contains un-escaped colon. In order to fix this issue, escaping first colon in command name on Windows and changing backslashes to slashes to make both `make` and `sh` happy
- Updated sourcegraph.com/sourcegraph/go-flags to sourcegraph/go-flags@7c86b1bed79b1dd42ee6650b6789776c40f78e12
- Java toolchain produces char-based offsets, we should convert them into byte-based offsets assuming that source code encoding is UTF-8. No CJK support yet

