### PR TITLE
cli: revert a part of PR #212

### DIFF
--- a/cli/config_cmd.go
+++ b/cli/config_cmd.go
@@ -240,6 +240,15 @@ WORKDIR /src
 			return err
 		}
 
+		// HACK: make the files writable by the docker user
+		//
+		// It is suspected that this is needed due to some older docker versions. We
+		// should investigate why it is needed for building e.g. the github.com/golang/go
+		// repository and remove this hack when possible.
+		if err := exec.Command("chmod", "-R", "777", dir).Run(); err != nil {
+			return fmt.Errorf("chmod -R 777 dir failed: %s", err)
+		}
+
 		for _, cmdStr := range cmds {
 			cmd := exec.Command("docker", "run", "-v", dir+":/src", "--rm", "--entrypoint=/bin/bash", containerName)
 			cmd.Args = append(cmd.Args, "-c", cmdStr)


### PR DESCRIPTION
This change reverts a part of PR #212 / 3dcee737b542f81af862a93449eb9deb855cce3f which
removed a hack on the pretense that it worked fine locally without it. Although it is
true that it works fine without it locally (e.g. running `srclib config -m docker` works),
we are seeing failures to build the github.com/golang/go repository due to file permission
errors:

```
##### Building Go bootstrap tool. cmd/dist
# _/src/src/cmd/dist cannot create cmd/dist/dist: Permission denied
PreConfigCommands: command "\nif [ -d /home/srclib ]; then\ncurl -L 'https://storage.googleapis.com/golang/go1.4.1.linux-amd64.tar.gz' > /tmp/go1.4.tgz &&\nmkdir /home/srclib/go1.4 &&\ntar -xf /tmp/go1.4.tgz -C /home/srclib/go1.4 --strip-components=1\nfi &&\ncd src\n./make.bash\n": exit status 2
```

Suspected is that older Docker versions handle the file permissions differently, thus it works
locally but not in prod.