### PR TITLE
Fix counter data race

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - go install ./cmd/srclib
 
 script:
-  - go test -v ./...
+  - go test -race -v ./...
   - make install-all-toolchains
   - make test-all-toolchains
 

--- a/store/counter.go
+++ b/store/counter.go
@@ -1,31 +1,23 @@
 package store
 
-import "sync"
+import "sync/atomic"
 
 // counter is a simple thread-safe integer.
 type counter struct {
-	sync.RWMutex
-	count int
+	count int64
 }
 
 // increment increments the counter by one.
-func (c *counter) increment() {
-	c.Lock()
-	c.count++
-	c.Unlock()
+func (c counter) increment() {
+	atomic.AddInt64(&c.count, 1)
 }
 
 // get returns the counter's current value.
 func (c *counter) get() int {
-	c.RLock()
-	v := c.count
-	c.RUnlock()
-	return v
+	return int(atomic.LoadInt64(&c.count))
 }
 
 // set sets the counter value.
 func (c *counter) set(i int) {
-	c.Lock()
-	c.count = i
-	c.Unlock()
+	atomic.StoreInt64(&c.count, int64(i))
 }

--- a/store/counter.go
+++ b/store/counter.go
@@ -4,20 +4,20 @@ import "sync/atomic"
 
 // counter is a simple thread-safe integer.
 type counter struct {
-	count int64
+	count *int64
 }
 
 // increment increments the counter by one.
 func (c counter) increment() {
-	atomic.AddInt64(&c.count, 1)
+	atomic.AddInt64(c.count, 1)
 }
 
 // get returns the counter's current value.
 func (c *counter) get() int {
-	return int(atomic.LoadInt64(&c.count))
+	return int(atomic.LoadInt64(c.count))
 }
 
 // set sets the counter value.
 func (c *counter) set(i int) {
-	atomic.StoreInt64(&c.count, int64(i))
+	atomic.StoreInt64(c.count, int64(i))
 }

--- a/store/counter.go
+++ b/store/counter.go
@@ -1,0 +1,31 @@
+package store
+
+import "sync"
+
+// counter is a simple thread-safe integer.
+type counter struct {
+	sync.RWMutex
+	count int
+}
+
+// increment increments the counter by one.
+func (c *counter) increment() {
+	c.Lock()
+	c.count++
+	c.Unlock()
+}
+
+// get returns the counter's current value.
+func (c *counter) get() int {
+	c.RLock()
+	v := c.count
+	c.RUnlock()
+	return v
+}
+
+// set sets the counter value.
+func (c *counter) set(i int) {
+	c.Lock()
+	c.count = i
+	c.Unlock()
+}

--- a/store/def_files_index.go
+++ b/store/def_files_index.go
@@ -38,7 +38,7 @@ var _ interface {
 	defIndex
 } = (*defFilesIndex)(nil)
 
-var c_defFilesIndex_getByPath = 0 // counter
+var c_defFilesIndex_getByPath = &counter{}
 
 func (x *defFilesIndex) String() string {
 	return fmt.Sprintf("defFilesIndex(ready=%v, filters=%v)", x.ready, x.filters)
@@ -50,7 +50,7 @@ func (x *defFilesIndex) String() string {
 // are returned.
 func (x *defFilesIndex) getByPath(path string) (byteOffsets, bool, error) {
 	vlog.Printf("defFilesIndex.getByPath(%s)", path)
-	c_defFilesIndex_getByPath++
+	c_defFilesIndex_getByPath.increment()
 
 	if x.phtable == nil {
 		panic("phtable not built/read")

--- a/store/def_files_index.go
+++ b/store/def_files_index.go
@@ -38,7 +38,7 @@ var _ interface {
 	defIndex
 } = (*defFilesIndex)(nil)
 
-var c_defFilesIndex_getByPath = &counter{}
+var c_defFilesIndex_getByPath = &counter{count: new(int64)}
 
 func (x *defFilesIndex) String() string {
 	return fmt.Sprintf("defFilesIndex(ready=%v, filters=%v)", x.ready, x.filters)

--- a/store/def_query_index.go
+++ b/store/def_query_index.go
@@ -30,7 +30,7 @@ var _ interface {
 	defIndex
 } = (*defQueryIndex)(nil)
 
-var c_defQueryIndex_getByQuery = &counter{}
+var c_defQueryIndex_getByQuery = &counter{count: new(int64)}
 
 func (x *defQueryIndex) String() string { return fmt.Sprintf("defQueryIndex(ready=%v)", x.ready) }
 

--- a/store/def_query_index.go
+++ b/store/def_query_index.go
@@ -30,13 +30,13 @@ var _ interface {
 	defIndex
 } = (*defQueryIndex)(nil)
 
-var c_defQueryIndex_getByQuery = 0 // counter
+var c_defQueryIndex_getByQuery = &counter{}
 
 func (x *defQueryIndex) String() string { return fmt.Sprintf("defQueryIndex(ready=%v)", x.ready) }
 
 func (x *defQueryIndex) getByQuery(q string) (byteOffsets, bool) {
 	vlog.Printf("defQueryIndex.getByQuery(%q)", q)
-	c_defQueryIndex_getByQuery++
+	c_defQueryIndex_getByQuery.increment()
 
 	if x.mt == nil {
 		panic("mafsaTable not built/read")

--- a/store/def_query_tree_index.go
+++ b/store/def_query_tree_index.go
@@ -29,7 +29,7 @@ var _ interface {
 	defTreeIndex
 } = (*defQueryTreeIndex)(nil)
 
-var c_defQueryTreeIndex_getByQuery = &counter{}
+var c_defQueryTreeIndex_getByQuery = &counter{count: new(int64)}
 
 func (x *defQueryTreeIndex) String() string {
 	return fmt.Sprintf("defQueryTreeIndex(ready=%v)", x.ready)

--- a/store/def_query_tree_index.go
+++ b/store/def_query_tree_index.go
@@ -29,7 +29,7 @@ var _ interface {
 	defTreeIndex
 } = (*defQueryTreeIndex)(nil)
 
-var c_defQueryTreeIndex_getByQuery = 0 // counter
+var c_defQueryTreeIndex_getByQuery = &counter{}
 
 func (x *defQueryTreeIndex) String() string {
 	return fmt.Sprintf("defQueryTreeIndex(ready=%v)", x.ready)
@@ -37,7 +37,7 @@ func (x *defQueryTreeIndex) String() string {
 
 func (x *defQueryTreeIndex) getByQuery(q string) (map[unit.ID2]byteOffsets, bool) {
 	vlog.Printf("defQueryTreeIndex.getByQuery(%q)", q)
-	c_defQueryTreeIndex_getByQuery++
+	c_defQueryTreeIndex_getByQuery.increment()
 
 	if x.mt == nil {
 		panic("mafsaTable not built/read")

--- a/store/def_ref_units_index.go
+++ b/store/def_ref_units_index.go
@@ -30,7 +30,7 @@ var _ interface {
 	unitIndex
 } = (*defRefUnitsIndex)(nil)
 
-var c_defRefUnitsIndex_getByDef = 0 // counter
+var c_defRefUnitsIndex_getByDef = &counter{}
 
 func (x *defRefUnitsIndex) String() string { return fmt.Sprintf("defRefUnitsIndex(ready=%v)", x.ready) }
 
@@ -38,7 +38,7 @@ func (x *defRefUnitsIndex) String() string { return fmt.Sprintf("defRefUnitsInde
 // specified def.
 func (x *defRefUnitsIndex) getByDef(def graph.RefDefKey) ([]unit.ID2, bool, error) {
 	vlog.Printf("defRefUnitsIndex.getByDef(%v)", def)
-	c_defRefUnitsIndex_getByDef++
+	c_defRefUnitsIndex_getByDef.increment()
 
 	k, err := proto.Marshal(&def)
 	if err != nil {

--- a/store/def_ref_units_index.go
+++ b/store/def_ref_units_index.go
@@ -30,7 +30,7 @@ var _ interface {
 	unitIndex
 } = (*defRefUnitsIndex)(nil)
 
-var c_defRefUnitsIndex_getByDef = &counter{}
+var c_defRefUnitsIndex_getByDef = &counter{count: new(int64)}
 
 func (x *defRefUnitsIndex) String() string { return fmt.Sprintf("defRefUnitsIndex(ready=%v)", x.ready) }
 

--- a/store/def_refs_index.go
+++ b/store/def_refs_index.go
@@ -26,7 +26,7 @@ var _ interface {
 	refIndexBuilder
 } = (*defRefsIndex)(nil)
 
-var c_defRefsIndex_getByDef = &counter{}
+var c_defRefsIndex_getByDef = &counter{count: new(int64)}
 
 func (x *defRefsIndex) String() string { return "defRefsIndex" }
 

--- a/store/def_refs_index.go
+++ b/store/def_refs_index.go
@@ -26,12 +26,12 @@ var _ interface {
 	refIndexBuilder
 } = (*defRefsIndex)(nil)
 
-var c_defRefsIndex_getByDef = 0 // counter
+var c_defRefsIndex_getByDef = &counter{}
 
 func (x *defRefsIndex) String() string { return "defRefsIndex" }
 
 func (x *defRefsIndex) getByDef(def graph.RefDefKey) (byteOffsets, bool, error) {
-	c_defRefsIndex_getByDef++
+	c_defRefsIndex_getByDef.increment()
 	if x.phtable == nil {
 		panic("phtable not built/read")
 	}

--- a/store/fs_store.go
+++ b/store/fs_store.go
@@ -296,7 +296,7 @@ func newFSTreeStore(fs rwvfs.FileSystem) *fsTreeStore {
 	return ts
 }
 
-var c_fsTreeStore_unitsOpened = 0 // counter
+var c_fsTreeStore_unitsOpened = &counter{}
 
 func (s *fsTreeStore) Units(f ...UnitFilter) ([]*unit.SourceUnit, error) {
 	var unitFilenames []string
@@ -320,7 +320,7 @@ func (s *fsTreeStore) Units(f ...UnitFilter) ([]*unit.SourceUnit, error) {
 
 	var units []*unit.SourceUnit
 	for _, filename := range unitFilenames {
-		c_fsTreeStore_unitsOpened++
+		c_fsTreeStore_unitsOpened.increment()
 		unit, err := s.openUnitFile(filename)
 		if err != nil {
 			return nil, err

--- a/store/fs_store.go
+++ b/store/fs_store.go
@@ -296,7 +296,7 @@ func newFSTreeStore(fs rwvfs.FileSystem) *fsTreeStore {
 	return ts
 }
 
-var c_fsTreeStore_unitsOpened = &counter{}
+var c_fsTreeStore_unitsOpened = &counter{count: new(int64)}
 
 func (s *fsTreeStore) Units(f ...UnitFilter) ([]*unit.SourceUnit, error) {
 	var unitFilenames []string

--- a/store/multi_repo_store_test.go
+++ b/store/multi_repo_store_test.go
@@ -421,7 +421,7 @@ func testMultiRepoStore_Defs_ByRepos_ByDefQuery(t *testing.T, mrs MultiRepoStore
 		}
 	}
 
-	c_defQueryTreeIndex_getByQuery = 0
+	c_defQueryTreeIndex_getByQuery.set(0)
 
 	want := []*graph.Def{
 		{DefKey: graph.DefKey{Repo: "r1", CommitID: "c", UnitType: "t", Unit: "u", Path: "p1"}, Name: "abc-r1"},
@@ -438,8 +438,8 @@ func testMultiRepoStore_Defs_ByRepos_ByDefQuery(t *testing.T, mrs MultiRepoStore
 		t.Errorf("%s: Defs: got defs %v, want %v", mrs, defs, want)
 	}
 	if isIndexedStore(mrs) {
-		if want := 2; c_defQueryTreeIndex_getByQuery != want {
-			t.Errorf("%s: Defs: got %d index hits on tree def query index, want %d", mrs, c_defQueryTreeIndex_getByQuery, want)
+		if want := 2; c_defQueryTreeIndex_getByQuery.get() != want {
+			t.Errorf("%s: Defs: got %d index hits on tree def query index, want %d", mrs, c_defQueryTreeIndex_getByQuery.get(), want)
 		}
 	}
 }
@@ -500,7 +500,7 @@ func testMultiRepoStore_Defs_ByRepoCommitIDs_ByDefQuery(t *testing.T, mrs MultiR
 		}
 	}
 
-	c_defQueryTreeIndex_getByQuery = 0
+	c_defQueryTreeIndex_getByQuery.set(0)
 
 	want := []*graph.Def{
 		{DefKey: graph.DefKey{Repo: "r1", CommitID: "c2", UnitType: "t", Unit: "u", Path: "p1"}, Name: "abc-r1"},
@@ -517,8 +517,8 @@ func testMultiRepoStore_Defs_ByRepoCommitIDs_ByDefQuery(t *testing.T, mrs MultiR
 		t.Errorf("%s: Defs: got defs %v, want %v", mrs, defs, want)
 	}
 	if isIndexedStore(mrs) {
-		if want := 2; c_defQueryTreeIndex_getByQuery != want {
-			t.Errorf("%s: Defs: got %d index hits on tree def query index, want %d", mrs, c_defQueryTreeIndex_getByQuery, want)
+		if want := 2; c_defQueryTreeIndex_getByQuery.get() != want {
+			t.Errorf("%s: Defs: got %d index hits on tree def query index, want %d", mrs, c_defQueryTreeIndex_getByQuery.get(), want)
 		}
 	}
 }

--- a/store/ref_file_index.go
+++ b/store/ref_file_index.go
@@ -23,13 +23,13 @@ var _ interface {
 	refIndexBuilder
 } = (*refFileIndex)(nil)
 
-var c_refFileIndex_getByFile = 0 // counter
+var c_refFileIndex_getByFile = &counter{}
 
 // getByFile returns a byteRanges describing the positions of refs in
 // the given source file (i.e., for which ref.File == file). The
 // byteRanges refer to offsets within the ref data file.
 func (x *refFileIndex) getByFile(file string) (byteRanges, bool, error) {
-	c_refFileIndex_getByFile++
+	c_refFileIndex_getByFile.increment()
 	if x.phtable == nil {
 		panic("phtable not built/read")
 	}

--- a/store/ref_file_index.go
+++ b/store/ref_file_index.go
@@ -23,7 +23,7 @@ var _ interface {
 	refIndexBuilder
 } = (*refFileIndex)(nil)
 
-var c_refFileIndex_getByFile = &counter{}
+var c_refFileIndex_getByFile = &counter{count: new(int64)}
 
 // getByFile returns a byteRanges describing the positions of refs in
 // the given source file (i.e., for which ref.File == file). The

--- a/store/repo_store_test.go
+++ b/store/repo_store_test.go
@@ -262,8 +262,8 @@ func testRepoStore_Defs_ByCommitIDs_ByFile(t *testing.T, rs RepoStoreImporter) {
 		{DefKey: graph.DefKey{CommitID: "c2", UnitType: "t", Unit: "u", Path: "p1"}, File: "f1"},
 	}
 
-	c_unitFilesIndex_getByPath = 0
-	c_defFilesIndex_getByPath = 0
+	c_unitFilesIndex_getByPath.set(0)
+	c_defFilesIndex_getByPath.set(0)
 	defs, err := rs.Defs(ByCommitIDs("c2"), ByFiles("f1"))
 	if err != nil {
 		t.Fatalf("%s: Defs: %s", rs, err)
@@ -272,11 +272,11 @@ func testRepoStore_Defs_ByCommitIDs_ByFile(t *testing.T, rs RepoStoreImporter) {
 		t.Errorf("%s: Defs: got defs %v, want %v", rs, defs, want)
 	}
 	if isIndexedStore(rs) {
-		if want := 1; c_unitFilesIndex_getByPath != want {
-			t.Errorf("%s: Defs: got %d unitFilesIndex hits, want %d", rs, c_unitFilesIndex_getByPath, want)
+		if want := 1; c_unitFilesIndex_getByPath.get() != want {
+			t.Errorf("%s: Defs: got %d unitFilesIndex hits, want %d", rs, c_unitFilesIndex_getByPath.get(), want)
 		}
-		if want := 1; c_defFilesIndex_getByPath != want {
-			t.Errorf("%s: Defs: got %d defFilesIndex hits, want %d", rs, c_defFilesIndex_getByPath, want)
+		if want := 1; c_defFilesIndex_getByPath.get() != want {
+			t.Errorf("%s: Defs: got %d defFilesIndex hits, want %d", rs, c_defFilesIndex_getByPath.get(), want)
 		}
 	}
 }

--- a/store/tree_store_test.go
+++ b/store/tree_store_test.go
@@ -142,8 +142,8 @@ func testTreeStore_Units(t *testing.T, ts TreeStoreImporter) {
 	}
 
 	{
-		c_fsTreeStore_unitsOpened = 0
-		c_unitsIndex_listUnits = 0
+		c_fsTreeStore_unitsOpened.set(0)
+		c_unitsIndex_listUnits.set(0)
 		units, err := ts.Units()
 		if err != nil {
 			t.Errorf("%s: Units(): %s", ts, err)
@@ -154,18 +154,18 @@ func testTreeStore_Units(t *testing.T, ts TreeStoreImporter) {
 			t.Errorf("%s: Units(): got %v, want %v", ts, units, want)
 		}
 		if isIndexedStore(ts) {
-			if want := 1; c_unitsIndex_listUnits != want {
-				t.Errorf("%s: Units: listed unitsIndex %dx, want %dx", ts, c_unitsIndex_listUnits, want)
+			if want := 1; c_unitsIndex_listUnits.get() != want {
+				t.Errorf("%s: Units: listed unitsIndex %dx, want %dx", ts, c_unitsIndex_listUnits.get(), want)
 			}
-			if want := 0; c_fsTreeStore_unitsOpened != want {
-				t.Errorf("%s: Units: got %d units opened, want %d (should use unitsIndex)", ts, c_fsTreeStore_unitsOpened, want)
+			if want := 0; c_fsTreeStore_unitsOpened.get() != want {
+				t.Errorf("%s: Units: got %d units opened, want %d (should use unitsIndex)", ts, c_fsTreeStore_unitsOpened.get(), want)
 			}
 		}
 	}
 
 	{
-		c_fsTreeStore_unitsOpened = 0
-		c_unitsIndex_listUnits = 0
+		c_fsTreeStore_unitsOpened.set(0)
+		c_unitsIndex_listUnits.set(0)
 
 		origMaxIndividualFetches := maxIndividualFetches
 		maxIndividualFetches = 1
@@ -187,11 +187,11 @@ func testTreeStore_Units(t *testing.T, ts TreeStoreImporter) {
 			t.Errorf("%s: Units(3 and 1): got %v, want %v", ts, units, want)
 		}
 		if isIndexedStore(ts) {
-			if want := 1; c_unitsIndex_listUnits != want {
-				t.Errorf("%s: Units: listed unitsIndex %dx, want %dx", ts, c_unitsIndex_listUnits, want)
+			if want := 1; c_unitsIndex_listUnits.get() != want {
+				t.Errorf("%s: Units: listed unitsIndex %dx, want %dx", ts, c_unitsIndex_listUnits.get(), want)
 			}
-			if want := 0; c_fsTreeStore_unitsOpened != want {
-				t.Errorf("%s: Units: got %d units opened, want %d (should use unitsIndex)", ts, c_fsTreeStore_unitsOpened, want)
+			if want := 0; c_fsTreeStore_unitsOpened.get() != want {
+				t.Errorf("%s: Units: got %d units opened, want %d (should use unitsIndex)", ts, c_fsTreeStore_unitsOpened.get(), want)
 			}
 		}
 	}
@@ -214,7 +214,7 @@ func testTreeStore_Units_ByFile(t *testing.T, ts TreeStoreImporter) {
 		}
 	}
 
-	c_unitFilesIndex_getByPath = 0
+	c_unitFilesIndex_getByPath.set(0)
 	units, err := ts.Units(ByFiles("f1"))
 	if err != nil {
 		t.Errorf("%s: Units(ByFiles f1): %s", ts, err)
@@ -225,12 +225,12 @@ func testTreeStore_Units_ByFile(t *testing.T, ts TreeStoreImporter) {
 		t.Errorf("%s: Units(ByFiles f1): got %v, want %v", ts, units, want)
 	}
 	if isIndexedStore(ts) {
-		if want := 1; c_unitFilesIndex_getByPath != want {
-			t.Errorf("%s: Units(ByFiles f1): got %d index hits, want %d", ts, c_unitFilesIndex_getByPath, want)
+		if want := 1; c_unitFilesIndex_getByPath.get() != want {
+			t.Errorf("%s: Units(ByFiles f1): got %d index hits, want %d", ts, c_unitFilesIndex_getByPath.get(), want)
 		}
 	}
 
-	c_unitFilesIndex_getByPath = 0
+	c_unitFilesIndex_getByPath.set(0)
 	units2, err := ts.Units(ByFiles("f2"))
 	if err != nil {
 		t.Errorf("%s: Units(ByFiles f2): %s", ts, err)
@@ -242,8 +242,8 @@ func testTreeStore_Units_ByFile(t *testing.T, ts TreeStoreImporter) {
 		t.Errorf("%s: Units(ByFiles f2): got %v, want %v", ts, units2, want2)
 	}
 	if isIndexedStore(ts) {
-		if want := 1; c_unitFilesIndex_getByPath != want {
-			t.Errorf("%s: Units(ByFiles f1): got %d index hits, want %d", ts, c_unitFilesIndex_getByPath, want)
+		if want := 1; c_unitFilesIndex_getByPath.get() != want {
+			t.Errorf("%s: Units(ByFiles f1): got %d index hits, want %d", ts, c_unitFilesIndex_getByPath.get(), want)
 		}
 	}
 }
@@ -434,8 +434,8 @@ func testTreeStore_Defs_Query(t *testing.T, ts TreeStoreImporter) {
 		},
 	}
 	for _, test := range tests {
-		c_defQueryTreeIndex_getByQuery = 0
-		c_defQueryIndex_getByQuery = 0
+		c_defQueryTreeIndex_getByQuery.set(0)
+		c_defQueryIndex_getByQuery.set(0)
 		defs, err := ts.Defs(ByDefQuery(test.q))
 		if err != nil {
 			t.Errorf("%s: Defs(ByDefQuery %q): %s", ts, test.q, err)
@@ -444,13 +444,13 @@ func testTreeStore_Defs_Query(t *testing.T, ts TreeStoreImporter) {
 			t.Errorf("%s: Defs(ByDefQuery %q): got defs %v, want %v", ts, test.q, got, want)
 		}
 		if isIndexedStore(ts) {
-			if want := test.wantIndexHits; c_defQueryTreeIndex_getByQuery != want {
-				t.Errorf("%s: Defs(ByDefQuery %q): got %d index hits, want %d", ts, test.q, c_defQueryTreeIndex_getByQuery, want)
+			if want := test.wantIndexHits; c_defQueryTreeIndex_getByQuery.get() != want {
+				t.Errorf("%s: Defs(ByDefQuery %q): got %d index hits, want %d", ts, test.q, c_defQueryTreeIndex_getByQuery.get(), want)
 			}
-			if c_defQueryIndex_getByQuery != 0 {
+			if c_defQueryIndex_getByQuery.get() != 0 {
 				// This query should only hit the tree-level def query
 				// index, not the def query indexes for each unit.
-				t.Errorf("%s: Defs(ByDefQuery %q): got %d index hits on non-tree index, want none", ts, test.q, c_defQueryIndex_getByQuery)
+				t.Errorf("%s: Defs(ByDefQuery %q): got %d index hits on non-tree index, want none", ts, test.q, c_defQueryIndex_getByQuery.get())
 			}
 		}
 	}
@@ -496,8 +496,8 @@ func testTreeStore_Defs_Query_ByUnit(t *testing.T, ts TreeStoreImporter) {
 		}
 	}
 
-	c_defQueryTreeIndex_getByQuery = 0
-	c_defQueryIndex_getByQuery = 0
+	c_defQueryTreeIndex_getByQuery.set(0)
+	c_defQueryIndex_getByQuery.set(0)
 	defs, err := ts.Defs(ByDefQuery("a"), ByUnits(unit.ID2{Type: "t", Name: "u1"}))
 	if err != nil {
 		t.Errorf("%s: Defs(ByDefQuery, ByUnit): %s", ts, err)
@@ -507,13 +507,13 @@ func testTreeStore_Defs_Query_ByUnit(t *testing.T, ts TreeStoreImporter) {
 		t.Errorf("%s: Defs(ByDefQuery, ByUnit): got defs %v, want %v", ts, got, want)
 	}
 	if isIndexedStore(ts) {
-		if want := 1; c_defQueryIndex_getByQuery != want {
-			t.Errorf("%s: Defs(ByDefQuery, ByUnit): got %d index hits, want %d", ts, c_defQueryIndex_getByQuery, want)
+		if want := 1; c_defQueryIndex_getByQuery.get() != want {
+			t.Errorf("%s: Defs(ByDefQuery, ByUnit): got %d index hits, want %d", ts, c_defQueryIndex_getByQuery.get(), want)
 		}
-		if c_defQueryTreeIndex_getByQuery != 0 {
+		if c_defQueryTreeIndex_getByQuery.get() != 0 {
 			// This query should only hit the unit-level def query
 			// index, not the tree-wide def query indexes.
-			t.Errorf("%s: Defs(ByDefQuery, ByUnit): got %d index hits on tree index, want none", ts, c_defQueryTreeIndex_getByQuery)
+			t.Errorf("%s: Defs(ByDefQuery, ByUnit): got %d index hits on tree index, want none", ts, c_defQueryTreeIndex_getByQuery.get())
 		}
 	}
 }
@@ -543,7 +543,7 @@ func testTreeStore_Defs_ByUnits(t *testing.T, ts TreeStoreImporter) {
 		{DefKey: graph.DefKey{UnitType: "t3", Unit: "u3", Path: "p3"}},
 	}
 
-	c_fsTreeStore_unitsOpened = 0
+	c_fsTreeStore_unitsOpened.set(0)
 	defs, err := ts.Defs(ByUnits(unit.ID2{Type: "t3", Name: "u3"}, unit.ID2{Type: "t1", Name: "u1"}))
 	if err != nil {
 		t.Errorf("%s: Defs(ByUnits): %s", ts, err)
@@ -554,8 +554,8 @@ func testTreeStore_Defs_ByUnits(t *testing.T, ts TreeStoreImporter) {
 		t.Errorf("%s: Defs(ByUnits): got defs %v, want %v", ts, defs, want)
 	}
 	if isIndexedStore(ts) {
-		if c_fsTreeStore_unitsOpened != 0 {
-			t.Errorf("%s: Defs(ByUnits): got %d units opened, want none (should be able to use ByUnits filter to avoid needing to open any units)", ts, c_fsTreeStore_unitsOpened)
+		if c_fsTreeStore_unitsOpened.get() != 0 {
+			t.Errorf("%s: Defs(ByUnits): got %d units opened, want none (should be able to use ByUnits filter to avoid needing to open any units)", ts, c_fsTreeStore_unitsOpened.get())
 		}
 	}
 }
@@ -583,7 +583,7 @@ func testTreeStore_Defs_ByFiles(t *testing.T, ts TreeStoreImporter) {
 		{DefKey: graph.DefKey{UnitType: "t2", Unit: "u2", Path: "p2"}, File: "f2"},
 	}
 
-	c_unitFilesIndex_getByPath = 0
+	c_unitFilesIndex_getByPath.set(0)
 	defs, err := ts.Defs(ByFiles("f2"))
 	if err != nil {
 		t.Errorf("%s: Defs(ByFiles f2): %s", ts, err)
@@ -592,8 +592,8 @@ func testTreeStore_Defs_ByFiles(t *testing.T, ts TreeStoreImporter) {
 		t.Errorf("%s: Defs(ByFiles f2): got defs %v, want %v", ts, defs, want)
 	}
 	if isIndexedStore(ts) {
-		if want := 1; c_unitFilesIndex_getByPath != want {
-			t.Errorf("%s: Defs(ByFiles f2): got %d index hits, want %d", ts, c_unitFilesIndex_getByPath, want)
+		if want := 1; c_unitFilesIndex_getByPath.get() != want {
+			t.Errorf("%s: Defs(ByFiles f2): got %d index hits, want %d", ts, c_unitFilesIndex_getByPath.get(), want)
 		}
 	}
 }
@@ -697,8 +697,8 @@ func testTreeStore_Refs_ByFiles(t *testing.T, ts TreeStoreImporter) {
 	}
 
 	for file, wantRefs := range refsByFile {
-		c_unitStores_Refs_last_numUnitsQueried = 0
-		c_refFileIndex_getByFile = 0
+		c_unitStores_Refs_last_numUnitsQueried.set(0)
+		c_refFileIndex_getByFile.set(0)
 		refs, err := ts.Refs(ByFiles(file))
 		if err != nil {
 			t.Fatalf("%s: Refs(ByFiles %s): %s", ts, file, err)
@@ -719,11 +719,11 @@ func testTreeStore_Refs_ByFiles(t *testing.T, ts TreeStoreImporter) {
 			t.Errorf("%s: Refs(ByFiles %s): got refs %v, want %v", ts, file, refs, want)
 		}
 		if isIndexedStore(ts) {
-			if want := len(distinctRefUnits); c_refFileIndex_getByFile != want {
-				t.Errorf("%s: Refs(ByFiles %s): got %d index hits, want %d", ts, file, c_refFileIndex_getByFile, want)
+			if want := len(distinctRefUnits); c_refFileIndex_getByFile.get() != want {
+				t.Errorf("%s: Refs(ByFiles %s): got %d index hits, want %d", ts, file, c_refFileIndex_getByFile.get(), want)
 			}
-			if want := len(distinctRefUnits); c_unitStores_Refs_last_numUnitsQueried != want {
-				t.Errorf("%s: Refs(ByFiles %s): got %d units queried, want %d", ts, file, c_unitStores_Refs_last_numUnitsQueried, want)
+			if want := len(distinctRefUnits); c_unitStores_Refs_last_numUnitsQueried.get() != want {
+				t.Errorf("%s: Refs(ByFiles %s): got %d units queried, want %d", ts, file, c_unitStores_Refs_last_numUnitsQueried.get(), want)
 			}
 		}
 	}
@@ -772,9 +772,9 @@ func testTreeStore_Refs_ByDef(t *testing.T, ts TreeStoreImporter) {
 		for defPath, wantRefs := range refsByDefPath {
 			defLabel := defUnit + ":" + defPath
 
-			c_unitStores_Refs_last_numUnitsQueried = 0
-			c_defRefsIndex_getByDef = 0
-			c_defRefUnitsIndex_getByDef = 0
+			c_unitStores_Refs_last_numUnitsQueried.set(0)
+			c_defRefsIndex_getByDef.set(0)
+			c_defRefUnitsIndex_getByDef.set(0)
 			refs, err := ts.Refs(ByRefDef(graph.RefDefKey{DefUnitType: "t", DefUnit: defUnit, DefPath: defPath}))
 			if err != nil {
 				t.Fatalf("%s: Refs(ByDef %s): %s", ts, defLabel, err)
@@ -795,14 +795,14 @@ func testTreeStore_Refs_ByDef(t *testing.T, ts TreeStoreImporter) {
 				t.Errorf("%s: Refs(ByDef %s): got refs %v, want %v", ts, defLabel, refs, want)
 			}
 			if isIndexedStore(ts) {
-				if want := len(distinctRefUnits); c_defRefsIndex_getByDef != want {
-					t.Errorf("%s: Refs(ByDef %s): got %d c_defRefsIndex_getByDef index hits, want %d", ts, defLabel, c_defRefsIndex_getByDef, want)
+				if want := len(distinctRefUnits); c_defRefsIndex_getByDef.get() != want {
+					t.Errorf("%s: Refs(ByDef %s): got %d c_defRefsIndex_getByDef index hits, want %d", ts, defLabel, c_defRefsIndex_getByDef.get(), want)
 				}
-				if want := 1; c_defRefUnitsIndex_getByDef != want {
-					t.Errorf("%s: Refs(ByDef %s): got %d c_defRefUnitsIndex_getByDef index hits, want %d", ts, defLabel, c_defRefUnitsIndex_getByDef, want)
+				if want := 1; c_defRefUnitsIndex_getByDef.get() != want {
+					t.Errorf("%s: Refs(ByDef %s): got %d c_defRefUnitsIndex_getByDef index hits, want %d", ts, defLabel, c_defRefUnitsIndex_getByDef.get(), want)
 				}
-				if want := len(distinctRefUnits); c_unitStores_Refs_last_numUnitsQueried != want {
-					t.Errorf("%s: Refs(ByDef %s): got %d units queried, want %d", ts, defLabel, c_unitStores_Refs_last_numUnitsQueried, want)
+				if want := len(distinctRefUnits); c_unitStores_Refs_last_numUnitsQueried.get() != want {
+					t.Errorf("%s: Refs(ByDef %s): got %d units queried, want %d", ts, defLabel, c_unitStores_Refs_last_numUnitsQueried.get(), want)
 				}
 			}
 		}

--- a/store/unit_files_index.go
+++ b/store/unit_files_index.go
@@ -28,7 +28,7 @@ var _ interface {
 	unitIndex
 } = (*unitFilesIndex)(nil)
 
-var c_unitFilesIndex_getByPath = 0 // counter
+var c_unitFilesIndex_getByPath = &counter{}
 
 func (x *unitFilesIndex) String() string { return fmt.Sprintf("unitFilesIndex(ready=%v)", x.ready) }
 
@@ -38,7 +38,7 @@ func (x *unitFilesIndex) String() string { return fmt.Sprintf("unitFilesIndex(re
 // are returned.
 func (x *unitFilesIndex) getByPath(path string) ([]unit.ID2, bool, error) {
 	vlog.Printf("unitFilesIndex.getByPath(%s)", path)
-	c_unitFilesIndex_getByPath++
+	c_unitFilesIndex_getByPath.increment()
 
 	if x.phtable == nil {
 		panic("phtable not built/read")

--- a/store/unit_files_index.go
+++ b/store/unit_files_index.go
@@ -28,7 +28,7 @@ var _ interface {
 	unitIndex
 } = (*unitFilesIndex)(nil)
 
-var c_unitFilesIndex_getByPath = &counter{}
+var c_unitFilesIndex_getByPath = &counter{count: new(int64)}
 
 func (x *unitFilesIndex) String() string { return fmt.Sprintf("unitFilesIndex(ready=%v)", x.ready) }
 

--- a/store/unit_store.go
+++ b/store/unit_store.go
@@ -80,7 +80,7 @@ func (s unitStores) Defs(fs ...DefFilter) ([]*graph.Def, error) {
 	return allDefs, err
 }
 
-var c_unitStores_Refs_last_numUnitsQueried = &counter{}
+var c_unitStores_Refs_last_numUnitsQueried = &counter{count: new(int64)}
 
 func (s unitStores) Refs(f ...RefFilter) ([]*graph.Ref, error) {
 	uss, err := openUnitStores(s.opener, f)

--- a/store/unit_store.go
+++ b/store/unit_store.go
@@ -80,7 +80,7 @@ func (s unitStores) Defs(fs ...DefFilter) ([]*graph.Def, error) {
 	return allDefs, err
 }
 
-var c_unitStores_Refs_last_numUnitsQueried = 0
+var c_unitStores_Refs_last_numUnitsQueried = &counter{}
 
 func (s unitStores) Refs(f ...RefFilter) ([]*graph.Ref, error) {
 	uss, err := openUnitStores(s.opener, f)
@@ -88,7 +88,7 @@ func (s unitStores) Refs(f ...RefFilter) ([]*graph.Ref, error) {
 		return nil, err
 	}
 
-	c_unitStores_Refs_last_numUnitsQueried = 0
+	c_unitStores_Refs_last_numUnitsQueried.set(0)
 	var (
 		allRefsMu sync.Mutex
 		allRefs   []*graph.Ref
@@ -100,7 +100,7 @@ func (s unitStores) Refs(f ...RefFilter) ([]*graph.Ref, error) {
 		}
 		u, us := u, us
 
-		c_unitStores_Refs_last_numUnitsQueried++
+		c_unitStores_Refs_last_numUnitsQueried.increment()
 
 		par.Do(func() error {
 			if _, moreOK := LimitRemaining(f); !moreOK {

--- a/store/unit_store_test.go
+++ b/store/unit_store_test.go
@@ -258,7 +258,7 @@ func testUnitStore_Defs_Query(t *testing.T, us UnitStoreImporter) {
 		},
 	}
 	for _, test := range tests {
-		c_defQueryIndex_getByQuery = 0
+		c_defQueryIndex_getByQuery.set(0)
 		defs, err := us.Defs(ByDefQuery(test.q))
 		if err != nil {
 			t.Errorf("%s: Defs(ByDefQuery %q): %s", us, test.q, err)
@@ -267,8 +267,8 @@ func testUnitStore_Defs_Query(t *testing.T, us UnitStoreImporter) {
 			t.Errorf("%s: Defs(ByDefQuery %q): got defs %v, want %v", us, test.q, got, want)
 		}
 		if isIndexedStore(us) {
-			if want := test.wantIndexHits; c_defQueryIndex_getByQuery != want {
-				t.Errorf("%s: Defs(ByDefQuery %q): got %d index hits, want %d", us, test.q, c_defQueryIndex_getByQuery, want)
+			if want := test.wantIndexHits; c_defQueryIndex_getByQuery.get() != want {
+				t.Errorf("%s: Defs(ByDefQuery %q): got %d index hits, want %d", us, test.q, c_defQueryIndex_getByQuery.get(), want)
 			}
 		}
 	}
@@ -332,7 +332,7 @@ func testUnitStore_Refs_ByFiles(t *testing.T, us UnitStoreImporter) {
 	}
 
 	for file, wantRefs := range refsByFile {
-		c_refFileIndex_getByFile = 0
+		c_refFileIndex_getByFile.set(0)
 		refs, err := us.Refs(ByFiles(file))
 		if err != nil {
 			t.Fatalf("%s: Refs(ByFiles %s): %s", us, file, err)
@@ -343,8 +343,8 @@ func testUnitStore_Refs_ByFiles(t *testing.T, us UnitStoreImporter) {
 			t.Errorf("%s: Refs(ByFiles %s): got refs %v, want %v", us, file, refs, want)
 		}
 		if isIndexedStore(us) {
-			if want := 1; c_refFileIndex_getByFile != want {
-				t.Errorf("%s: Refs(ByFiles %s): got %d index hits, want %d", us, file, c_refFileIndex_getByFile, want)
+			if want := 1; c_refFileIndex_getByFile.get() != want {
+				t.Errorf("%s: Refs(ByFiles %s): got %d index hits, want %d", us, file, c_refFileIndex_getByFile.get(), want)
 			}
 		}
 	}
@@ -378,7 +378,7 @@ func testUnitStore_Refs_ByDef(t *testing.T, us UnitStoreImporter) {
 	}
 
 	for defPath, wantRefs := range refsByDef {
-		c_defRefsIndex_getByDef = 0
+		c_defRefsIndex_getByDef.set(0)
 		refs, err := us.Refs(ByRefDef(graph.RefDefKey{DefPath: defPath}))
 		if err != nil {
 			t.Fatalf("%s: Refs(ByDefs %s): %s", us, defPath, err)
@@ -389,8 +389,8 @@ func testUnitStore_Refs_ByDef(t *testing.T, us UnitStoreImporter) {
 			t.Errorf("%s: Refs(ByDefs %s): got refs %v, want %v", us, defPath, refs, want)
 		}
 		if isIndexedStore(us) {
-			if want := 1; c_defRefsIndex_getByDef != want {
-				t.Errorf("%s: Refs(ByDefs %s): got %d index hits, want %d", us, defPath, c_defRefsIndex_getByDef, want)
+			if want := 1; c_defRefsIndex_getByDef.get() != want {
+				t.Errorf("%s: Refs(ByDefs %s): got %d index hits, want %d", us, defPath, c_defRefsIndex_getByDef.get(), want)
 			}
 		}
 	}

--- a/store/units_index.go
+++ b/store/units_index.go
@@ -22,7 +22,7 @@ var _ interface {
 	unitFullIndex
 } = (*unitsIndex)(nil)
 
-var c_unitsIndex_listUnits = 0 // counter
+var c_unitsIndex_listUnits = &counter{}
 
 func (x *unitsIndex) String() string { return fmt.Sprintf("unitsIndex(ready=%v)", x.ready) }
 
@@ -38,7 +38,7 @@ func (x *unitsIndex) Units(fs ...UnitFilter) ([]*unit.SourceUnit, error) {
 		panic("units not built/read")
 	}
 
-	c_unitsIndex_listUnits++
+	c_unitsIndex_listUnits.increment()
 
 	var units []*unit.SourceUnit
 	for _, u := range x.units {

--- a/store/units_index.go
+++ b/store/units_index.go
@@ -22,7 +22,7 @@ var _ interface {
 	unitFullIndex
 } = (*unitsIndex)(nil)
 
-var c_unitsIndex_listUnits = &counter{}
+var c_unitsIndex_listUnits = &counter{count: new(int64)}
 
 func (x *unitsIndex) String() string { return fmt.Sprintf("unitsIndex(ready=%v)", x.ready) }
 


### PR DESCRIPTION
This change fixes many data races present in the tests, where the actual method being tested runs several other goroutines, with each trying to touch a global counter variable. After this change, I am able to successfully run all tests with the race detector enabled.

Also enable the Go race detector in Travis, to help catch these in the future.