### PR TITLE
Improvements for docker mode

### DIFF
--- a/cli/test_cmd.go
+++ b/cli/test_cmd.go
@@ -115,8 +115,7 @@ func (c *TestCmd) Execute(args []string) error {
 			expectedDir := filepath.Join(tree, "../../expected", exeMethod, filepath.Base(tree))
 			actualDir := filepath.Join(tree, "../../actual", exeMethod, filepath.Base(tree))
 
-			_, err := os.Stat(expectedDir)
-			if err != nil && os.IsNotExist(err) {
+			if _, err := os.Stat(expectedDir); err != nil && os.IsNotExist(err) {
 				// (alexsaveliev) we may have some tests available only for docker or program mode
 				if GlobalOpt.Verbose {
 					log.Printf("Skipping tree %v...", tree)

--- a/cli/test_cmd.go
+++ b/cli/test_cmd.go
@@ -114,6 +114,16 @@ func (c *TestCmd) Execute(args []string) error {
 			}
 			expectedDir := filepath.Join(tree, "../../expected", exeMethod, filepath.Base(tree))
 			actualDir := filepath.Join(tree, "../../actual", exeMethod, filepath.Base(tree))
+
+			_, err := os.Stat(expectedDir)
+			if err != nil && os.IsNotExist(err) {
+				// (alexsaveliev) we may have some tests available only for docker or program mode
+				if GlobalOpt.Verbose {
+					log.Printf("Skipping tree %v...", tree)
+				}
+				continue
+			}
+
 			if err := testTree(tree, expectedDir, actualDir, exeMethod, c.GenerateExpected); err != nil {
 				return fmt.Errorf("testing tree %q: %s", tree, err)
 			}
@@ -281,7 +291,7 @@ func (c *DiffCmd) Execute(args []string) error {
 			differingDefs = append(differingDefs, defKey)
 		}
 	}
-	for defKey, _ := range actDefs {
+	for defKey := range actDefs {
 		if _, exists := expDefs[defKey]; !exists {
 			actOnlyDefs = append(actOnlyDefs, defKey)
 		}

--- a/cli/test_cmd.go
+++ b/cli/test_cmd.go
@@ -114,15 +114,6 @@ func (c *TestCmd) Execute(args []string) error {
 			}
 			expectedDir := filepath.Join(tree, "../../expected", exeMethod, filepath.Base(tree))
 			actualDir := filepath.Join(tree, "../../actual", exeMethod, filepath.Base(tree))
-
-			if _, err := os.Stat(expectedDir); err != nil && os.IsNotExist(err) {
-				// (alexsaveliev) we may have some tests available only for docker or program mode
-				if GlobalOpt.Verbose {
-					log.Printf("Skipping tree %v...", tree)
-				}
-				continue
-			}
-
 			if err := testTree(tree, expectedDir, actualDir, exeMethod, c.GenerateExpected); err != nil {
 				return fmt.Errorf("testing tree %q: %s", tree, err)
 			}

--- a/dep/resolve.go
+++ b/dep/resolve.go
@@ -2,10 +2,6 @@ package dep
 
 import (
 	"encoding/json"
-	"sort"
-
-	"sourcegraph.com/sourcegraph/srclib/graph"
-	"sourcegraph.com/sourcegraph/srclib/unit"
 )
 
 // START ResolvedTarget OMIT
@@ -67,52 +63,6 @@ func (r *Resolution) RawKeyId() (string, error) {
 
 // Command for dep resolution has no options.
 type Command struct{}
-
-// ResolutionsToResolvedDeps converts a []*Resolution for a source unit to a
-// []*ResolvedDep (which is a data structure that includes the source unit
-// type/name/etc., so elements are meaningful even if the associated source unit
-// struct is not available).
-//
-// Resolutions with Errors are omitted from the returned slice and no such
-// errors are returned.
-func ResolutionsToResolvedDeps(ress []*Resolution, unit *unit.SourceUnit, fromRepo string, fromCommitID string) ([]*ResolvedDep, error) {
-	or := func(a, b string) string {
-		if a != "" {
-			return a
-		}
-		return b
-	}
-	var resolved []*ResolvedDep
-	for _, res := range ress {
-		if res.Error != "" {
-			continue
-		}
-
-		if rt := res.Target; rt != nil {
-			var uri string
-			if rt.ToRepoCloneURL != "" {
-				uri = graph.MakeURI(rt.ToRepoCloneURL)
-			} else {
-				uri = fromRepo
-			}
-
-			rd := &ResolvedDep{
-				FromRepo:        fromRepo,
-				FromCommitID:    fromCommitID,
-				FromUnit:        unit.Name,
-				FromUnitType:    unit.Type,
-				ToRepo:          uri,
-				ToUnit:          or(rt.ToUnit, unit.Name),
-				ToUnitType:      or(rt.ToUnitType, unit.Type),
-				ToVersionString: rt.ToVersionString,
-				ToRevSpec:       rt.ToRevSpec,
-			}
-			resolved = append(resolved, rd)
-		}
-	}
-	sort.Sort(resolvedDeps(resolved))
-	return resolved, nil
-}
 
 type resolvedDeps []*ResolvedDep
 

--- a/graph/repo.go
+++ b/graph/repo.go
@@ -8,6 +8,19 @@ import (
 	"strings"
 )
 
+// MakeURI converts a repository clone URL, such as
+// "git://github.com/user/repo.git", to a normalized URI string, such
+// as "github.com/user/repo" lexically. MakeURI panics if there is an
+// error, and should only be used if cloneURL is a correctly-formed
+// URL. It is a wrapper around TryMakeURI.
+func MakeURI(cloneURL string) string {
+	uri, err := TryMakeURI(cloneURL)
+	if err != nil {
+		panic(err)
+	}
+	return uri
+}
+
 // TryMakeURI converts a repository clone URL, such as
 // "git://github.com/user/repo.git", to a normalized URI string, such
 // as "github.com/user/repo" lexically. TryMakeURI returns an error if

--- a/grapher/grapher.go
+++ b/grapher/grapher.go
@@ -95,13 +95,21 @@ func NormalizeData(currentRepoURI, unitType, dir string, o *graph.Output) error 
 			ref.DefRepo = ""
 		}
 		if ref.DefRepo != "" {
-			ref.DefRepo = graph.MakeURI(string(ref.DefRepo))
+			uri, err := graph.TryMakeURI(string(ref.DefRepo))
+			if err != nil {
+				return err
+			}
+			ref.DefRepo = uri
 		}
 		if ref.Repo == currentRepoURI {
 			ref.Repo = ""
 		}
 		if ref.Repo != "" {
-			ref.Repo = graph.MakeURI(string(ref.Repo))
+			uri, err := graph.TryMakeURI(string(ref.Repo))
+			if err != nil {
+				return err
+			}
+			ref.Repo = uri
 		}
 	}
 

--- a/toolchain/toolchain.go
+++ b/toolchain/toolchain.go
@@ -237,10 +237,6 @@ func (t *dockerToolchain) Command() (*exec.Cmd, error) {
 	//   "--user", "srclib"
 	// to the run options below.
 	var cmd *exec.Cmd
-	if strings.HasSuffix(t.imageName, "srclib-java") { // HACK for srclib-java
-		cmd = exec.Command("docker", "run", "--memory=4g", "-i", "--volume="+t.hostVolumeDir+":/src", t.imageName)
-	} else {
-		cmd = exec.Command("docker", "run", "--memory=4g", "-i", "--volume="+t.hostVolumeDir+":/src:ro", t.imageName)
-	}
+	cmd = exec.Command("docker", "run", "--memory=4g", "-i", "--volume="+t.hostVolumeDir+":/src:ro", t.imageName)
 	return cmd, nil
 }


### PR DESCRIPTION
- removed hack for srclib-java in Docker mode
- returning error instead of panicking when we were unable to normalize repo clone URI