### PR TITLE
Tolerating missing files

### DIFF
--- a/grapher/rule.go
+++ b/grapher/rule.go
@@ -3,6 +3,7 @@ package grapher
 import (
 	"fmt"
 	"log"
+	"os"
 	"path/filepath"
 
 	"sourcegraph.com/sourcegraph/makex"
@@ -58,7 +59,13 @@ func (r *GraphUnitRule) Target() string {
 
 func (r *GraphUnitRule) Prereqs() []string {
 	ps := []string{filepath.ToSlash(filepath.Join(r.dataDir, plan.SourceUnitDataFilename(unit.SourceUnit{}, r.Unit)))}
-	ps = append(ps, r.Unit.Files...)
+	for _, file := range r.Unit.Files {
+		if _, err := os.Stat(file); err != nil && os.IsNotExist(err) {
+			// skip not-existent files listed in source unit
+			continue
+		}
+		ps = append(ps, file)
+	}
 	return ps
 }
 

--- a/plan/makefile_test.go
+++ b/plan/makefile_test.go
@@ -42,7 +42,7 @@ all: testdata/n/t.depresolve.json testdata/n/t.graph.json
 testdata/n/t.depresolve.json: testdata/n/t.unit.json
 	srclib tool  "tc" "t" < $^ 1> $@
 
-testdata/n/t.graph.json: testdata/n/t.unit.json f
+testdata/n/t.graph.json: testdata/n/t.unit.json
 	srclib tool  "tc" "t" < $< | srclib internal normalize-graph-data --unit-type "t" --dir . 1> $@
 
 .DELETE_ON_ERROR:


### PR DESCRIPTION
- When file is present in unit's Files section but it's absent on disk, we should exclude it from Makefile prerequisites instead of terminating program execution. This situation may occur for example when file is being generated during compile phase if toolchain runs in the Docker mode: generated source file may be detected and included into Files, but after Docker container is stopped, file is no longer accessible.
