### PR TITLE
docker: Use --rm for run

### DIFF
--- a/toolchain/toolchain.go
+++ b/toolchain/toolchain.go
@@ -237,6 +237,6 @@ func (t *dockerToolchain) Command() (*exec.Cmd, error) {
 	//   "--user", "srclib"
 	// to the run options below.
 	var cmd *exec.Cmd
-	cmd = exec.Command("docker", "run", "--memory=4g", "-i", "--volume="+t.hostVolumeDir+":/src:ro", t.imageName)
+	cmd = exec.Command("docker", "run", "--rm=true", "--memory=4g", "-i", "--volume="+t.hostVolumeDir+":/src:ro", t.imageName)
 	return cmd, nil
 }


### PR DESCRIPTION
What we run is ephemeral, but docker by default leaves the container around even
once it has exited. This is causing issues in production since we have 10s of
thousands instances in `docker ps -a`, which seems to be causing perf issues in
docker.