### PR TITLE
update import path for rog-go

### DIFF
--- a/buildstore/store.go
+++ b/buildstore/store.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strconv"
 
-	"code.google.com/p/rog-go/parallel"
+	"github.com/rogpeppe/rog-go/parallel"
 
 	"github.com/kr/fs"
 

--- a/cli/repo_config.go
+++ b/cli/repo_config.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"path/filepath"
 
-	"code.google.com/p/rog-go/parallel"
+	"github.com/rogpeppe/rog-go/parallel"
 
 	"os"
 	"os/exec"

--- a/cli/store_cmds.go
+++ b/cli/store_cmds.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"time"
 
-	"code.google.com/p/rog-go/parallel"
+	"github.com/rogpeppe/rog-go/parallel"
 
 	"github.com/alexsaveliev/go-colorable-wrapper"
 

--- a/config/cached.go
+++ b/config/cached.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"code.google.com/p/rog-go/parallel"
+	"github.com/rogpeppe/rog-go/parallel"
 
 	"github.com/kr/fs"
 	"golang.org/x/tools/godoc/vfs"

--- a/gendata/simple.go
+++ b/gendata/simple.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"code.google.com/p/rog-go/parallel"
+	"github.com/rogpeppe/rog-go/parallel"
 
 	"sourcegraph.com/sourcegraph/srclib/dep"
 	"sourcegraph.com/sourcegraph/srclib/graph"

--- a/gendata/urefs.go
+++ b/gendata/urefs.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"code.google.com/p/rog-go/parallel"
+	"github.com/rogpeppe/rog-go/parallel"
 
 	"sync"
 

--- a/scan/scan.go
+++ b/scan/scan.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"sync"
 
-	"code.google.com/p/rog-go/parallel"
+	"github.com/rogpeppe/rog-go/parallel"
 	"sourcegraph.com/sourcegraph/srclib/config"
 	"sourcegraph.com/sourcegraph/srclib/flagutil"
 	"sourcegraph.com/sourcegraph/srclib/toolchain"

--- a/store/fs_store.go
+++ b/store/fs_store.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"code.google.com/p/rog-go/parallel"
+	"github.com/rogpeppe/rog-go/parallel"
 
 	"github.com/kr/fs"
 	"golang.org/x/tools/godoc/vfs"

--- a/store/indexed.go
+++ b/store/indexed.go
@@ -11,7 +11,7 @@ import (
 
 	"compress/gzip"
 
-	"code.google.com/p/rog-go/parallel"
+	"github.com/rogpeppe/rog-go/parallel"
 
 	"sort"
 	"strings"

--- a/store/indexes.go
+++ b/store/indexes.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"time"
 
-	"code.google.com/p/rog-go/parallel"
+	"github.com/rogpeppe/rog-go/parallel"
 
 	"strings"
 	"sync"

--- a/store/repo_store.go
+++ b/store/repo_store.go
@@ -3,7 +3,7 @@ package store
 import (
 	"sync"
 
-	"code.google.com/p/rog-go/parallel"
+	"github.com/rogpeppe/rog-go/parallel"
 	"sourcegraph.com/sourcegraph/srclib/graph"
 	"sourcegraph.com/sourcegraph/srclib/unit"
 )

--- a/store/unit_store.go
+++ b/store/unit_store.go
@@ -3,7 +3,7 @@ package store
 import (
 	"sync"
 
-	"code.google.com/p/rog-go/parallel"
+	"github.com/rogpeppe/rog-go/parallel"
 	"sourcegraph.com/sourcegraph/srclib/graph"
 )
 


### PR DESCRIPTION
`code.google.com/p/rog-go -> github.com/rogpeppe/rog-go`

This is to eliminate the need for `hg` when building srclib. This is the last `hg` dep.