### PR TITLE
allow importing when no toolchains are present

### DIFF
--- a/dep/rule.go
+++ b/dep/rule.go
@@ -36,7 +36,7 @@ func makeDepRules(c *config.Tree, dataDir string, existing []makex.Rule, opt pla
 		}
 
 		rules = append(rules, &ResolveDepsRule{dataDir, u, toolRef, opt})
-		if opt.Verbose {
+		if toolRef != nil && opt.Verbose {
 			log.Printf("Created %v rule for %v %v", depresolveOp, toolRef.Toolchain, u.ID())
 		}
 	}
@@ -59,6 +59,9 @@ func (r *ResolveDepsRule) Prereqs() []string {
 }
 
 func (r *ResolveDepsRule) Recipes() []string {
+	if r.Tool == nil {
+		return nil
+	}
 	return []string{
 		fmt.Sprintf("%s tool %s %q %q < $^ 1> $@", util.SafeCommandName(srclib.CommandName), r.opt.ToolchainExecOpt, r.Tool.Toolchain, r.Tool.Subcmd),
 	}

--- a/grapher/rule.go
+++ b/grapher/rule.go
@@ -38,10 +38,9 @@ func makeGraphRules(c *config.Tree, dataDir string, existing []makex.Rule, opt p
 		}
 
 		rules = append(rules, &GraphUnitRule{dataDir, u, toolRef, opt})
-		if opt.Verbose {
+		if toolRef != nil && opt.Verbose {
 			log.Printf("Created %v rule for %v %v", graphOp, toolRef.Toolchain, u.ID())
 		}
-
 	}
 	return rules, nil
 }
@@ -70,6 +69,9 @@ func (r *GraphUnitRule) Prereqs() []string {
 }
 
 func (r *GraphUnitRule) Recipes() []string {
+	if r.Tool == nil {
+		return nil
+	}
 	safeCommand := util.SafeCommandName(srclib.CommandName)
 	return []string{
 		fmt.Sprintf("%s tool %s %q %q < $< | %s internal normalize-graph-data --unit-type %q --dir . 1> $@", safeCommand, r.opt.ToolchainExecOpt, r.Tool.Toolchain, r.Tool.Subcmd, safeCommand, r.Unit.Type),

--- a/toolchain/choose.go
+++ b/toolchain/choose.go
@@ -2,21 +2,8 @@ package toolchain
 
 import (
 	"fmt"
-	"os"
-
-	"strconv"
 
 	"sourcegraph.com/sourcegraph/srclib"
-)
-
-var (
-	// NoToolchains operates srclib in no-toolchain mode, where it
-	// does not try to look for system toolchains in your SRCLIBPATH.
-	NoToolchains, _ = strconv.ParseBool(os.Getenv("SRCLIB_NO_TOOLCHAINS"))
-
-	// noneToolchain is returned by ChooseTool when NoToolchains is
-	// true.
-	noneToolchain = &srclib.ToolRef{Toolchain: "NONE", Subcmd: "NONE"}
 )
 
 // ChooseTool determines which toolchain and tool to use to run op (graph,
@@ -28,9 +15,6 @@ var (
 // more than 1 are found, then an error is returned. TODO(sqs): extend this to
 // choose the "best" tool when multiple tools would suffice.
 func ChooseTool(op, unitType string) (*srclib.ToolRef, error) {
-	if NoToolchains {
-		return noneToolchain, nil
-	}
 	tcs, err := List()
 	if err != nil {
 		return nil, err
@@ -59,10 +43,10 @@ func chooseTool(op, unitType string, tcs []*Info) (*srclib.ToolRef, error) {
 		}
 	}
 
-	if n := len(satisfying); n == 0 {
-		return nil, fmt.Errorf("no tool satisfies op %q for source unit type %q", op, unitType)
-	} else if n > 1 {
+	if n := len(satisfying); n > 1 {
 		return nil, fmt.Errorf("%d tools satisfy op %q for source unit type %q (refusing to choose between multiple possibilities)", n, op, unitType)
+	} else if n == 0 {
+		return nil, nil
 	}
 	return satisfying[0], nil
 }

--- a/toolchain/find.go
+++ b/toolchain/find.go
@@ -15,11 +15,6 @@ import (
 // Lookup finds a toolchain by path in the SRCLIBPATH. For each DIR in
 // SRCLIBPATH, it checks for the existence of DIR/PATH/Srclibtoolchain.
 func Lookup(path string) (*Info, error) {
-
-	if NoToolchains {
-		return nil, nil
-	}
-
 	path = filepath.Clean(path)
 
 	dir, err := Dir(path)
@@ -59,10 +54,6 @@ func lookupToolchain(toolchainPath string) (string, error) {
 // dir (with a DIR/Srclibtoolchain file), then none of DIR's
 // subdirectories are searched for toolchains.
 func List() ([]*Info, error) {
-	if NoToolchains {
-		return nil, nil
-	}
-
 	var found []*Info
 	seen := map[string]string{}
 


### PR DESCRIPTION
Removes the SRCLIB_NO_TOOLCHAINS env var, which permitted `srclib
store import` operations (and other things that depended on already
produced data) even when no toolchains were present. This behavior is
now the standard behavior.

This could make it slightly more confusing if you are trying to debug
why a scanned source unit is not being passed to a grapher (e.g., if
you specify the wrong ToolRef to use to graph the source unit), but it
comes at a significant decrease in complexity overall.