### PR TITLE
cli: expose AddCommands to allow mounting srclib as a subcommand of another CLI

### DIFF
--- a/cli/api_cmds.go
+++ b/cli/api_cmds.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/alexsaveliev/go-colorable-wrapper"
 	"github.com/kr/fs"
+	"sourcegraph.com/sourcegraph/go-flags"
 
 	"sourcegraph.com/sourcegraph/rwvfs"
 	"sourcegraph.com/sourcegraph/srclib"
@@ -24,70 +25,72 @@ import (
 )
 
 func init() {
-	c, err := CLI.AddCommand("api",
-		"API",
-		"",
-		&apiCmd,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
+	cliInit = append(cliInit, func(cli *flags.Command) {
+		c, err := cli.AddCommand("api",
+			"API",
+			"",
+			&apiCmd,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
 
-	/* START APIDescribeCmdDoc OMIT
-	This command is used by editor plugins to retrieve information about
-	the identifier at a specific position in a file.
+		/* START APIDescribeCmdDoc OMIT
+		This command is used by editor plugins to retrieve information about
+		the identifier at a specific position in a file.
 
-	It will hit Sourcegraph's API to get a definition's examples. With the
-	flag `--no-examples`, this command does not hit Sourcegraph's API.
-		END APIDescribeCmdDoc OMIT */
-	_, err = c.AddCommand("describe",
-		"display documentation for the def under the cursor",
-		"Returns information about the definition referred to by the cursor's current position in a file.",
-		&apiDescribeCmd,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
+		It will hit Sourcegraph's API to get a definition's examples. With the
+		flag `--no-examples`, this command does not hit Sourcegraph's API.
+			END APIDescribeCmdDoc OMIT */
+		_, err = c.AddCommand("describe",
+			"display documentation for the def under the cursor",
+			"Returns information about the definition referred to by the cursor's current position in a file.",
+			&apiDescribeCmd,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
 
-	/* START APIListCmdDoc OMIT
-	This command will return a list of all the definitions,
-	references, and docs in a file. It can be used for finding all
-	uses of a reference in a file.
-	END APIListCmdDoc OMIT */
-	_, err = c.AddCommand("list",
-		"list all defs, refs, and docs in a given file",
-		"Return a list of all definitions, references, and docs that are in the current file.",
-		&apiListCmd,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
+		/* START APIListCmdDoc OMIT
+		This command will return a list of all the definitions,
+		references, and docs in a file. It can be used for finding all
+		uses of a reference in a file.
+		END APIListCmdDoc OMIT */
+		_, err = c.AddCommand("list",
+			"list all defs, refs, and docs in a given file",
+			"Return a list of all definitions, references, and docs that are in the current file.",
+			&apiListCmd,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
 
-	/* START APIDepsCmdDoc OMIT
-	This command returns a list of all resolved and unresolved
-	dependencies for the current repository.
-		END APIDepsCmdDoc OMIT */
-	_, err = c.AddCommand("deps",
-		"list all resolved and unresolved dependencies",
-		`Return a list of all resolved and unresolved dependencies that are in the current repository.`,
-		&apiDepsCmd,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
+		/* START APIDepsCmdDoc OMIT
+		This command returns a list of all resolved and unresolved
+		dependencies for the current repository.
+			END APIDepsCmdDoc OMIT */
+		_, err = c.AddCommand("deps",
+			"list all resolved and unresolved dependencies",
+			`Return a list of all resolved and unresolved dependencies that are in the current repository.`,
+			&apiDepsCmd,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
 
-	/* START APIUnitsCmdDoc OMIT
-	This command returns a list of all of the source units in the current
-	repository.
-		END APIUnitsCmdDoc OMIT */
-	_, err = c.AddCommand("units",
-		"list all source unit information",
-		"Return a list of all source units that are in the current repository.",
-		&apiUnitsCmd,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
+		/* START APIUnitsCmdDoc OMIT
+		This command returns a list of all of the source units in the current
+		repository.
+			END APIUnitsCmdDoc OMIT */
+		_, err = c.AddCommand("units",
+			"list all source unit information",
+			"Return a list of all source units that are in the current repository.",
+			&apiUnitsCmd,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+	})
 }
 
 type APICmd struct{}

--- a/cli/config_cmd.go
+++ b/cli/config_cmd.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"sort"
 
+	"sourcegraph.com/sourcegraph/go-flags"
+
 	"sourcegraph.com/sourcegraph/rwvfs"
 	"sourcegraph.com/sourcegraph/srclib/buildstore"
 	"sourcegraph.com/sourcegraph/srclib/config"
@@ -21,9 +23,10 @@ import (
 )
 
 func init() {
-	c, err := CLI.AddCommand("config",
-		"reads & scans for project configuration",
-		`Produces a configuration file suitable for building the repository or directory tree rooted at DIR (or the current directory if not specified).
+	cliInit = append(cliInit, func(cli *flags.Command) {
+		c, err := cli.AddCommand("config",
+			"reads & scans for project configuration",
+			`Produces a configuration file suitable for building the repository or directory tree rooted at DIR (or the current directory if not specified).
 
 The steps are:
 
@@ -35,15 +38,16 @@ The steps are:
 
 The default values for --repo and --subdir are determined by detecting the current repository and reading its Srcfile config (if any).
 `,
-		&configCmd,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
-	c.Aliases = []string{"c"}
+			&configCmd,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+		c.Aliases = []string{"c"}
 
-	SetDefaultRepoOpt(c)
-	setDefaultRepoSubdirOpt(c)
+		SetDefaultRepoOpt(c)
+		setDefaultRepoSubdirOpt(c)
+	})
 }
 
 // getInitialConfig gets the initial config (i.e., the config that comes solely

--- a/cli/doall_cmd.go
+++ b/cli/doall_cmd.go
@@ -4,22 +4,26 @@ import (
 	"log"
 	"os"
 
+	"sourcegraph.com/sourcegraph/go-flags"
+
 	"sourcegraph.com/sourcegraph/srclib/config"
 )
 
 func init() {
-	// TODO(sqs): "do-all" is a stupid name
-	c, err := CLI.AddCommand("do-all",
-		"fully process (config, plan, execute, and import)",
-		`Fully processes a tree: configures it, plans the execution, executes all analysis steps, and imports the data.`,
-		&doAllCmd,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
+	cliInit = append(cliInit, func(cli *flags.Command) {
+		// TODO(sqs): "do-all" is a stupid name
+		c, err := cli.AddCommand("do-all",
+			"fully process (config, plan, execute, and import)",
+			`Fully processes a tree: configures it, plans the execution, executes all analysis steps, and imports the data.`,
+			&doAllCmd,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
 
-	SetDefaultRepoOpt(c)
-	setDefaultRepoSubdirOpt(c)
+		SetDefaultRepoOpt(c)
+		setDefaultRepoSubdirOpt(c)
+	})
 }
 
 type DoAllCmd struct {

--- a/cli/gen_data_cmd.go
+++ b/cli/gen_data_cmd.go
@@ -3,35 +3,39 @@ package cli
 import (
 	"log"
 
+	"sourcegraph.com/sourcegraph/go-flags"
+
 	"sourcegraph.com/sourcegraph/srclib/gendata"
 )
 
 func init() {
-	c, err := CLI.AddCommand("gen-data",
-		"generates fake data",
-		`generates fake data for testing and benchmarking purposes. Run this command inside an empty or expendable directory.`,
-		&gendata.GenDataCmd{},
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
-	c.Aliases = []string{"c"}
+	cliInit = append(cliInit, func(cli *flags.Command) {
+		c, err := cli.AddCommand("gen-data",
+			"generates fake data",
+			`generates fake data for testing and benchmarking purposes. Run this command inside an empty or expendable directory.`,
+			&gendata.GenDataCmd{},
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+		c.Aliases = []string{"c"}
 
-	_, err = c.AddCommand("simple",
-		"generates a simple repository",
-		"generates a simple repository with the specified source unit and file structure, with the given number of defs and refs to those defs in each file",
-		&gendata.SimpleRepoCmd{},
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
+		_, err = c.AddCommand("simple",
+			"generates a simple repository",
+			"generates a simple repository with the specified source unit and file structure, with the given number of defs and refs to those defs in each file",
+			&gendata.SimpleRepoCmd{},
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
 
-	_, err = c.AddCommand("urefs",
-		"generates a repository with cross-unit references",
-		"generates a repository with cross-unit references with the given unit and file structure, the number of defs in each file, and refs from each source unit to each def",
-		&gendata.URefsRepoCmd{},
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
+		_, err = c.AddCommand("urefs",
+			"generates a repository with cross-unit references",
+			"generates a repository with cross-unit references with the given unit and file structure, the number of defs in each file, and refs from each source unit to each def",
+			&gendata.URefsRepoCmd{},
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+	})
 }

--- a/cli/info_cmds.go
+++ b/cli/info_cmds.go
@@ -3,20 +3,24 @@ package cli
 import (
 	"log"
 
+	"sourcegraph.com/sourcegraph/go-flags"
+
 	"sourcegraph.com/sourcegraph/srclib"
 	"sourcegraph.com/sourcegraph/srclib/buildstore"
 	"sourcegraph.com/sourcegraph/srclib/plan"
 )
 
 func init() {
-	_, err := CLI.AddCommand("info",
-		"show info about enabled capabilities",
-		"Shows information about enabled capabilities in this tool as well as system information.",
-		&infoCmd,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
+	cliInit = append(cliInit, func(cli *flags.Command) {
+		_, err := cli.AddCommand("info",
+			"show info about enabled capabilities",
+			"Shows information about enabled capabilities in this tool as well as system information.",
+			&infoCmd,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+	})
 }
 
 type InfoCmd struct{}

--- a/cli/internal_data_cmds.go
+++ b/cli/internal_data_cmds.go
@@ -5,20 +5,24 @@ import (
 	"log"
 	"os"
 
+	"sourcegraph.com/sourcegraph/go-flags"
+
 	"sourcegraph.com/sourcegraph/srclib/graph"
 	"sourcegraph.com/sourcegraph/srclib/grapher"
 )
 
 func init() {
-	c, err := CLI.AddCommand("internal", "(internal subcommands - do not use)", "Internal subcommands. Do not use.", &struct{}{})
-	if err != nil {
-		log.Fatal(err)
-	}
+	cliInit = append(cliInit, func(cli *flags.Command) {
+		c, err := cli.AddCommand("internal", "(internal subcommands - do not use)", "Internal subcommands. Do not use.", &struct{}{})
+		if err != nil {
+			log.Fatal(err)
+		}
 
-	_, err = c.AddCommand("normalize-graph-data", "", "", &normalizeGraphDataCmd)
-	if err != nil {
-		log.Fatal(err)
-	}
+		_, err = c.AddCommand("normalize-graph-data", "", "", &normalizeGraphDataCmd)
+		if err != nil {
+			log.Fatal(err)
+		}
+	})
 }
 
 type NormalizeGraphDataCmd struct {

--- a/cli/lint_cmd.go
+++ b/cli/lint_cmd.go
@@ -17,12 +17,14 @@ import (
 
 	"github.com/alexsaveliev/go-colorable-wrapper"
 	"github.com/kr/fs"
+	"sourcegraph.com/sourcegraph/go-flags"
 )
 
 func init() {
-	c, err := CLI.AddCommand("lint",
-		"detect common issues in srclib output data",
-		`The lint command checks srclib output files (*.graph.json, *.unit.json, *.depresolve.json, etc.) for common data integrity and correctness issues:
+	cliInit = append(cliInit, func(cli *flags.Command) {
+		c, err := cli.AddCommand("lint",
+			"detect common issues in srclib output data",
+			`The lint command checks srclib output files (*.graph.json, *.unit.json, *.depresolve.json, etc.) for common data integrity and correctness issues:
 
 * Refs that point to nonexistent defs in the same source unit
 
@@ -34,13 +36,14 @@ If no PATHs are specified, the current directory is used. If a PATH is a directo
 
 To suppress specific kinds of warnings, or to include only specific kinds of warnings, pipe the output of the lint command through grep.
 `,
-		&lintCmd,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
+			&lintCmd,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
 
-	SetDefaultRepoOpt(c)
+		SetDefaultRepoOpt(c)
+	})
 }
 
 type LintCmd struct {

--- a/cli/make_cmd.go
+++ b/cli/make_cmd.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/alexsaveliev/go-colorable-wrapper"
+	"sourcegraph.com/sourcegraph/go-flags"
 
 	"sourcegraph.com/sourcegraph/makex"
 	"sourcegraph.com/sourcegraph/srclib"
@@ -18,17 +19,19 @@ import (
 )
 
 func init() {
-	c, err := CLI.AddCommand("make",
-		"plans and executes plan",
-		`Generates a plan (in Makefile form, in memory) for analyzing the tree and executes the plan. `,
-		&makeCmd,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
+	cliInit = append(cliInit, func(cli *flags.Command) {
+		c, err := cli.AddCommand("make",
+			"plans and executes plan",
+			`Generates a plan (in Makefile form, in memory) for analyzing the tree and executes the plan. `,
+			&makeCmd,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
 
-	SetDefaultRepoOpt(c)
-	setDefaultRepoSubdirOpt(c)
+		SetDefaultRepoOpt(c)
+		setDefaultRepoSubdirOpt(c)
+	})
 }
 
 type MakeCmd struct {

--- a/cli/makefile_cmd.go
+++ b/cli/makefile_cmd.go
@@ -4,18 +4,22 @@ import (
 	"log"
 	"os"
 
+	"sourcegraph.com/sourcegraph/go-flags"
+
 	"sourcegraph.com/sourcegraph/makex"
 )
 
 func init() {
-	_, err := CLI.AddCommand("makefile",
-		"prints the Makefile that the `make` subcommand executes",
-		"The makefile command prints the Makefile that the `make` subcommand will execute.",
-		&makefileCmd,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
+	cliInit = append(cliInit, func(cli *flags.Command) {
+		_, err := cli.AddCommand("makefile",
+			"prints the Makefile that the `make` subcommand executes",
+			"The makefile command prints the Makefile that the `make` subcommand will execute.",
+			&makefileCmd,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+	})
 }
 
 type MakefileCmd struct {

--- a/cli/repo_cmds.go
+++ b/cli/repo_cmds.go
@@ -4,17 +4,20 @@ import (
 	"log"
 
 	"github.com/alexsaveliev/go-colorable-wrapper"
+	"sourcegraph.com/sourcegraph/go-flags"
 )
 
 func init() {
-	_, err := CLI.AddCommand("repo",
-		"display current repo info",
-		"The repo subcommand displays autodetected info about the current repo.",
-		&repoCmd{},
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
+	cliInit = append(cliInit, func(cli *flags.Command) {
+		_, err := cli.AddCommand("repo",
+			"display current repo info",
+			"The repo subcommand displays autodetected info about the current repo.",
+			&repoCmd{},
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+	})
 }
 
 type repoCmd struct{}

--- a/cli/selfupdate_cmd.go
+++ b/cli/selfupdate_cmd.go
@@ -6,17 +6,20 @@ import (
 	"sourcegraph.com/sourcegraph/srclib"
 
 	"github.com/sqs/go-selfupdate/selfupdate"
+	"sourcegraph.com/sourcegraph/go-flags"
 )
 
 func init() {
-	_, err := CLI.AddCommand("selfupdate",
-		"update this program",
-		"The selfupdate command updates the srclib binary.",
-		&selfUpdateCmd,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
+	cliInit = append(cliInit, func(cli *flags.Command) {
+		_, err := cli.AddCommand("selfupdate",
+			"update this program",
+			"The selfupdate command updates the srclib binary.",
+			&selfUpdateCmd,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+	})
 }
 
 var selfUpdateCmd SelfUpdateCmd

--- a/cli/store_cmds.go
+++ b/cli/store_cmds.go
@@ -34,27 +34,29 @@ import (
 )
 
 func init() {
-	storeC, err := CLI.AddCommand("store",
-		"graph store commands",
-		"",
-		&storeCmd,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
-	lrepo, _ := OpenLocalRepo()
-	if lrepo != nil && lrepo.RootDir != "" {
-		absDir, err := os.Getwd()
+	cliInit = append(cliInit, func(cli *flags.Command) {
+		storeC, err := cli.AddCommand("store",
+			"graph store commands",
+			"",
+			&storeCmd,
+		)
 		if err != nil {
 			log.Fatal(err)
 		}
-		relDir, err := filepath.Rel(absDir, lrepo.RootDir)
-		if err == nil {
-			SetOptionDefaultValue(storeC.Group, "root", filepath.Join(relDir, store.SrclibStoreDir))
+		lrepo, _ := OpenLocalRepo()
+		if lrepo != nil && lrepo.RootDir != "" {
+			absDir, err := os.Getwd()
+			if err != nil {
+				log.Fatal(err)
+			}
+			relDir, err := filepath.Rel(absDir, lrepo.RootDir)
+			if err == nil {
+				SetOptionDefaultValue(storeC.Group, "root", filepath.Join(relDir, store.SrclibStoreDir))
+			}
 		}
-	}
 
-	InitStoreCmds(storeC)
+		InitStoreCmds(storeC)
+	})
 }
 
 func InitStoreCmds(c *flags.Command) {

--- a/cli/test_cmd.go
+++ b/cli/test_cmd.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/alexsaveliev/go-colorable-wrapper"
+	"sourcegraph.com/sourcegraph/go-flags"
 
 	"sourcegraph.com/sourcegraph/srclib"
 	"sourcegraph.com/sourcegraph/srclib/buildstore"
@@ -22,9 +23,10 @@ import (
 )
 
 func init() {
-	_, err := CLI.AddCommand("test",
-		"run test cases",
-		`Tests a tool. If no TREEs are specified, all directories in testdata/case relative to the current directory are
+	cliInit = append(cliInit, func(cli *flags.Command) {
+		_, err := cli.AddCommand("test",
+			"run test cases",
+			`Tests a tool. If no TREEs are specified, all directories in testdata/case relative to the current directory are
 used (except those whose name begins with "_").
 
 Expected and actual outputs for a tree are stored in TREE/../../{expected,actual}/TREEBASE, respectively, where TREEBASE is the basename of TREE.
@@ -51,19 +53,20 @@ And the actual test output is written to:
 
   testdata/actual/foo/*
 `,
-		&testCmd,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
+			&testCmd,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
 
-	_, err = CLI.AddCommand("diff",
-		"display semantic diff of two output files",
-		"Displays easier-to-read diff of two srclib output files. Intended for debugging use when developing srclib toolchains",
-		&diffCmd)
-	if err != nil {
-		log.Fatal(err)
-	}
+		_, err = cli.AddCommand("diff",
+			"display semantic diff of two output files",
+			"Displays easier-to-read diff of two srclib output files. Intended for debugging use when developing srclib toolchains",
+			&diffCmd)
+		if err != nil {
+			log.Fatal(err)
+		}
+	})
 }
 
 type TestCmd struct {

--- a/cli/tool_cmd.go
+++ b/cli/tool_cmd.go
@@ -14,15 +14,17 @@ import (
 )
 
 func init() {
-	c, err := CLI.AddCommand("tool",
-		"run a tool",
-		"Run a srclib tool with the specified arguments.",
-		&toolCmd,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
-	c.ArgsRequired = true
+	cliInit = append(cliInit, func(cli *flags.Command) {
+		c, err := cli.AddCommand("tool",
+			"run a tool",
+			"Run a srclib tool with the specified arguments.",
+			&toolCmd,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+		c.ArgsRequired = true
+	})
 }
 
 type ToolCmd struct {

--- a/cli/toolchain_cmd.go
+++ b/cli/toolchain_cmd.go
@@ -21,60 +21,62 @@ import (
 )
 
 func init() {
-	c, err := CLI.AddCommand("toolchain",
-		"manage toolchains",
-		"Manage srclib toolchains.",
-		&toolchainCmd,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
-	c.Aliases = []string{"tc"}
+	cliInit = append(cliInit, func(cli *flags.Command) {
+		c, err := cli.AddCommand("toolchain",
+			"manage toolchains",
+			"Manage srclib toolchains.",
+			&toolchainCmd,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+		c.Aliases = []string{"tc"}
 
-	_, err = c.AddCommand("list",
-		"list available toolchains",
-		"List available toolchains.",
-		&toolchainListCmd,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
+		_, err = c.AddCommand("list",
+			"list available toolchains",
+			"List available toolchains.",
+			&toolchainListCmd,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
 
-	_, err = c.AddCommand("list-tools",
-		"list tools in toolchains",
-		"List available tools in all toolchains.",
-		&toolchainListToolsCmd,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
+		_, err = c.AddCommand("list-tools",
+			"list tools in toolchains",
+			"List available tools in all toolchains.",
+			&toolchainListToolsCmd,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
 
-	_, err = c.AddCommand("bundle",
-		"bundle a toolchain",
-		"The bundle subcommand builds and archives toolchain bundles (.tar.gz files, one per toolchain variant). Bundles contain prebuilt toolchains and allow people to use srclib toolchains without needing to compile them on their own system.",
-		&toolchainBundleCmd,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
+		_, err = c.AddCommand("bundle",
+			"bundle a toolchain",
+			"The bundle subcommand builds and archives toolchain bundles (.tar.gz files, one per toolchain variant). Bundles contain prebuilt toolchains and allow people to use srclib toolchains without needing to compile them on their own system.",
+			&toolchainBundleCmd,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
 
-	_, err = c.AddCommand("unbundle",
-		"unbundle a toolchain",
-		"The unbundle subcommand unarchives a toolchain bundle (previously created with the 'bundle' subcommand). It allows people to download and use prebuilt toolchains without needing to compile them on their system.",
-		&toolchainUnbundleCmd,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
+		_, err = c.AddCommand("unbundle",
+			"unbundle a toolchain",
+			"The unbundle subcommand unarchives a toolchain bundle (previously created with the 'bundle' subcommand). It allows people to download and use prebuilt toolchains without needing to compile them on their system.",
+			&toolchainUnbundleCmd,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
 
-	_, err = c.AddCommand("install",
-		"install toolchains",
-		"Download and install toolchains",
-		&toolchainInstallCmd,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
+		_, err = c.AddCommand("install",
+			"install toolchains",
+			"Download and install toolchains",
+			&toolchainInstallCmd,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+	})
 }
 
 type ToolchainPath string
@@ -530,7 +532,6 @@ Refusing to install Basic toolchain because %s is not installed or is not on the
 
 	return nil
 }
-
 
 func cloneToolchain(dest, toolchain string) error {
 	if fi, err := os.Stat(dest); os.IsNotExist(err) {

--- a/cli/units_cmd.go
+++ b/cli/units_cmd.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/alexsaveliev/go-colorable-wrapper"
+	"sourcegraph.com/sourcegraph/go-flags"
 
 	"sourcegraph.com/sourcegraph/srclib/config"
 	"sourcegraph.com/sourcegraph/srclib/scan"
@@ -15,17 +16,19 @@ import (
 )
 
 func init() {
-	c, err := CLI.AddCommand("units",
-		"lists source units",
-		`Lists source units in the repository or directory tree rooted at DIR (or the current directory if DIR is not specified).`,
-		&unitsCmd,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
+	cliInit = append(cliInit, func(cli *flags.Command) {
+		c, err := cli.AddCommand("units",
+			"lists source units",
+			`Lists source units in the repository or directory tree rooted at DIR (or the current directory if DIR is not specified).`,
+			&unitsCmd,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
 
-	SetDefaultRepoOpt(c)
-	setDefaultRepoSubdirOpt(c)
+		SetDefaultRepoOpt(c)
+		setDefaultRepoSubdirOpt(c)
+	})
 }
 
 // scanUnitsIntoConfig uses cfg to scan for source units. It modifies

--- a/cli/version_cmd.go
+++ b/cli/version_cmd.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/alexsaveliev/go-colorable-wrapper"
+	"sourcegraph.com/sourcegraph/go-flags"
 )
 
 // Version of srclib.
@@ -13,14 +14,16 @@ import (
 var Version = "dev"
 
 func init() {
-	_, err := CLI.AddCommand("version",
-		"show version",
-		"The version subcommand displays the current version of this srclib program.",
-		&versionCmd{},
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
+	cliInit = append(cliInit, func(cli *flags.Command) {
+		_, err := cli.AddCommand("version",
+			"show version",
+			"The version subcommand displays the current version of this srclib program.",
+			&versionCmd{},
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+	})
 }
 
 type versionCmd struct{}


### PR DESCRIPTION
This lets you create another program "myprogram" that mounts srclib's CLI as "myprogram srclib ...". For example, "myprogram srclib toolchain list" would run that subcommand of srclib.

Mostly an internal change only likely to affect (and benefit) Sourcegraph.