### PR TITLE
{store,cli}: add specific option (no prefixes) to ByFiles

### DIFF
--- a/cli/store_cmds.go
+++ b/cli/store_cmds.go
@@ -865,7 +865,7 @@ func (c *StoreUnitsCmd) filters() []store.UnitFilter {
 		fs = append(fs, makeRepoCommitIDsFilter(c.RepoCommitIDs))
 	}
 	if c.File != "" {
-		fs = append(fs, store.ByFiles(path.Clean(c.File)))
+		fs = append(fs, store.ByFiles(false, path.Clean(c.File)))
 	}
 	return fs
 }
@@ -932,7 +932,7 @@ func (c *StoreDefsCmd) filters() []store.DefFilter {
 		fs = append(fs, store.ByDefPath(c.Path))
 	}
 	if c.File != "" {
-		fs = append(fs, store.ByFiles(path.Clean(c.File)))
+		fs = append(fs, store.ByFiles(false, path.Clean(c.File)))
 	}
 	if c.Query != "" {
 		fs = append(fs, store.ByDefQuery(c.Query))
@@ -1019,7 +1019,7 @@ func (c *StoreRefsCmd) filters() []store.RefFilter {
 		fs = append(fs, makeRepoCommitIDsFilter(c.RepoCommitIDs))
 	}
 	if c.File != "" {
-		fs = append(fs, store.ByFiles(path.Clean(c.File)))
+		fs = append(fs, store.ByFiles(false, path.Clean(c.File)))
 	}
 	if c.Start != 0 {
 		fs = append(fs, store.RefFilterFunc(func(ref *graph.Ref) bool {

--- a/store/bench_test.go
+++ b/store/bench_test.go
@@ -173,7 +173,7 @@ func benchmarkDefsByFile(b *testing.B, rs RepoStoreImporter, numDefs int) {
 	commitID := fmt.Sprintf("commit%d", *numVersions/2)
 	defFilter := []DefFilter{
 		ByCommitIDs(commitID),
-		ByFiles("file0"),
+		ByFiles(false, "file0"),
 	}
 
 	runtime.GC()
@@ -196,7 +196,7 @@ func benchmarkRefsByFile(b *testing.B, rs RepoStoreImporter, numRefs int) {
 	commitID := fmt.Sprintf("commit%d", *numVersions/2)
 	refFilter := []RefFilter{
 		ByCommitIDs(commitID),
-		ByFiles("file0"),
+		ByFiles(false, "file0"),
 	}
 
 	runtime.GC()

--- a/store/filter.go
+++ b/store/filter.go
@@ -702,10 +702,9 @@ type ByFilesFilter interface {
 // empty, or if the file path has not been cleaned (i.e., if file !=
 // path.Clean(file)).
 //
-// If specific == true, then only the specific files are accepted (i.e. a
-// directory path will not include all files in that directory as it would
-// normally).
-func ByFiles(specific bool, files ...string) interface {
+// If exact == true, then only the exact files are accepted (i.e. a directory
+// path will not include all files in that directory as it would normally).
+func ByFiles(exact bool, files ...string) interface {
 	DefFilter
 	RefFilter
 	UnitFilter
@@ -719,21 +718,21 @@ func ByFiles(specific bool, files ...string) interface {
 			panic("file: not cleaned (file != path.Clean(file))")
 		}
 	}
-	return byFilesFilter{files: files, specific: specific}
+	return byFilesFilter{files: files, exact: exact}
 }
 
 type byFilesFilter struct {
-	files    []string
-	specific bool
+	files []string
+	exact bool
 }
 
 func (f byFilesFilter) String() string {
-	return fmt.Sprintf("ByFiles(%v, specific=%t)", ([]string)(f.files), f.specific)
+	return fmt.Sprintf("ByFiles(%v, exact=%t)", ([]string)(f.files), f.exact)
 }
 func (f byFilesFilter) ByFiles() []string { return f.files }
 func (f byFilesFilter) SelectDef(def *graph.Def) bool {
 	for _, ff := range f.files {
-		if def.File == ff || (!f.specific && strings.HasPrefix(def.File, ff+"/")) {
+		if def.File == ff || (!f.exact && strings.HasPrefix(def.File, ff+"/")) {
 			return true
 		}
 	}
@@ -741,7 +740,7 @@ func (f byFilesFilter) SelectDef(def *graph.Def) bool {
 }
 func (f byFilesFilter) SelectRef(ref *graph.Ref) bool {
 	for _, ff := range f.files {
-		if ref.File == ff || (!f.specific && strings.HasPrefix(ref.File, ff+"/")) {
+		if ref.File == ff || (!f.exact && strings.HasPrefix(ref.File, ff+"/")) {
 			return true
 		}
 	}
@@ -750,7 +749,7 @@ func (f byFilesFilter) SelectRef(ref *graph.Ref) bool {
 func (f byFilesFilter) SelectUnit(unit *unit.SourceUnit) bool {
 	for _, unitFile := range unit.Files {
 		for _, ff := range f.files {
-			if ff == unitFile || (!f.specific && strings.HasPrefix(unitFile, ff+"/")) {
+			if ff == unitFile || (!f.exact && strings.HasPrefix(unitFile, ff+"/")) {
 				return true
 			}
 		}

--- a/store/repo_store_test.go
+++ b/store/repo_store_test.go
@@ -263,7 +263,7 @@ func testRepoStore_Defs_ByCommitIDs_ByFile(t *testing.T, rs RepoStoreImporter) {
 	}
 
 	c_unitFilesIndex_getByPath.set(0)
-	defs, err := rs.Defs(ByCommitIDs("c2"), ByFiles("f1"))
+	defs, err := rs.Defs(ByCommitIDs("c2"), ByFiles(false, "f1"))
 	if err != nil {
 		t.Fatalf("%s: Defs: %s", rs, err)
 	}

--- a/store/tree_store_test.go
+++ b/store/tree_store_test.go
@@ -215,7 +215,7 @@ func testTreeStore_Units_ByFile(t *testing.T, ts TreeStoreImporter) {
 	}
 
 	c_unitFilesIndex_getByPath.set(0)
-	units, err := ts.Units(ByFiles("f1"))
+	units, err := ts.Units(ByFiles(false, "f1"))
 	if err != nil {
 		t.Errorf("%s: Units(ByFiles f1): %s", ts, err)
 	}
@@ -231,7 +231,7 @@ func testTreeStore_Units_ByFile(t *testing.T, ts TreeStoreImporter) {
 	}
 
 	c_unitFilesIndex_getByPath.set(0)
-	units2, err := ts.Units(ByFiles("f2"))
+	units2, err := ts.Units(ByFiles(false, "f2"))
 	if err != nil {
 		t.Errorf("%s: Units(ByFiles f2): %s", ts, err)
 	}
@@ -584,7 +584,7 @@ func testTreeStore_Defs_ByFiles(t *testing.T, ts TreeStoreImporter) {
 	}
 
 	c_unitFilesIndex_getByPath.set(0)
-	defs, err := ts.Defs(ByFiles("f2"))
+	defs, err := ts.Defs(ByFiles(false, "f2"))
 	if err != nil {
 		t.Errorf("%s: Defs(ByFiles f2): %s", ts, err)
 	}
@@ -699,7 +699,7 @@ func testTreeStore_Refs_ByFiles(t *testing.T, ts TreeStoreImporter) {
 	for file, wantRefs := range refsByFile {
 		c_unitStores_Refs_last_numUnitsQueried.set(0)
 		c_refFileIndex_getByFile.set(0)
-		refs, err := ts.Refs(ByFiles(file))
+		refs, err := ts.Refs(ByFiles(false, file))
 		if err != nil {
 			t.Fatalf("%s: Refs(ByFiles %s): %s", ts, file, err)
 		}

--- a/store/unit_store_test.go
+++ b/store/unit_store_test.go
@@ -333,7 +333,7 @@ func testUnitStore_Refs_ByFiles(t *testing.T, us UnitStoreImporter) {
 
 	for file, wantRefs := range refsByFile {
 		c_refFileIndex_getByFile.set(0)
-		refs, err := us.Refs(ByFiles(file))
+		refs, err := us.Refs(ByFiles(false, file))
 		if err != nil {
 			t.Fatalf("%s: Refs(ByFiles %s): %s", us, file, err)
 		}


### PR DESCRIPTION
This change adds a `exact` flag to the `ByFiles` filter such that it will
not be inclusive of files matching the prefix (e.g. `foo/` does not match
`foo/bar.go`).