### PR TITLE
Removed garbage log output

### DIFF
--- a/grapher/grapher.go
+++ b/grapher/grapher.go
@@ -58,10 +58,6 @@ func ensureOffsetsAreByteOffsets(dir string, output *graph.Output) {
 			if *offset == 0 {
 				continue
 			}
-			before, after := *offset, uint32(f.ByteOffsetOfRune(int(*offset)))
-			if before != after {
-				log.Printf("Changed pos %d to %d in %s", before, after, filename)
-			}
 			*offset = uint32(f.ByteOffsetOfRune(int(*offset)))
 		}
 	}


### PR DESCRIPTION
When source code contains multibyte UTF-8 characters there is a lot of "Changed pos X to Y in foo/bar" messages in log. I think they are useless and pollute logs so I propose to remove them