### PR TITLE
Handling UTF-8 BOM and adjusting srclib-csharp offsets

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -70,7 +70,7 @@
 		},
 		{
 			"ImportPath": "github.com/sqs/fileset",
-			"Rev": "4317e899aa9438ba7603a6e322389571cb3ffdff"
+			"Rev": "af79d58d268e6fb30711babccd37156c95fd5aaf"
 		},
 		{
 			"ImportPath": "github.com/sqs/go-selfupdate/selfupdate",

--- a/grapher/grapher.go
+++ b/grapher/grapher.go
@@ -100,7 +100,7 @@ func NormalizeData(unitType, dir string, o *graph.Output) error {
 		}
 	}
 
-	if unitType != "GoPackage" && unitType != "Dockerfile" && unitType != "NugetPackage" {
+	if unitType != "GoPackage" && unitType != "Dockerfile" {
 		ensureOffsetsAreByteOffsets(dir, o)
 	}
 


### PR DESCRIPTION
- Bumping version of `github.com/sqs/fileset` to include recent changes related to UTF-8 BOM support
- `srclib-csharp` emits defs and refs character-based offsets so they need to be converted to byte ones.
