### PR TITLE
Windows support: dealing with Srcfile

### DIFF
--- a/config/validate.go
+++ b/config/validate.go
@@ -22,6 +22,7 @@ func (c *Tree) validate() error {
 			if p == ".." || strings.HasPrefix(p, ".."+string(filepath.Separator)) {
 				return ErrInvalidFilePath
 			}
+			p = filepath.ToSlash(p)
 		}
 	}
 	return nil

--- a/unit/source_unit.go
+++ b/unit/source_unit.go
@@ -205,7 +205,9 @@ func ExpandPaths(base string, paths []string) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		expanded = append(expanded, hits...)
+		for _, hit := range hits {
+			expanded = append(expanded, filepath.ToSlash(hit))
+		}
 	}
 	return expanded, nil
 }


### PR DESCRIPTION
- using Unix-style separator for Srcfile's Files
- converting Files to Unix style during validation