### PR TITLE
Fixes sourcegraph/srclib#242

### DIFF
--- a/graph/repo.go
+++ b/graph/repo.go
@@ -37,9 +37,7 @@ func TryMakeURI(cloneURL string) (string, error) {
 	}
 
 	// Removing leading "scm:" if any
-	if strings.HasPrefix(cloneURL, "scm:") {
-		cloneURL = cloneURL[4:]
-	}
+	cloneURL = strings.TrimPrefix(cloneURL, "scm:")
 
 	// Removing VCS part if any, git:http://.. => http://..
 	cloneURL = removeVCSPart(cloneURL)
@@ -74,7 +72,7 @@ func URIEqual(a, b string) bool {
 	return strings.EqualFold(a, b)
 }
 
-// Removes VCS part if any, git:http://.. => http://..
+// removeVCSPart removes VCS part from URL if any, git:http://.. => http://..
 func removeVCSPart(url string) string {
 	parts := strings.SplitN(url, ":", 3)
 	if len(parts) < 3 {
@@ -94,7 +92,7 @@ func removeVCSPart(url string) string {
 	return parts[1] + ":" + parts[2]
 }
 
-// Returns true if given rune is ASCII letter
+// isASCIILetter reports if given rune is an ASCII letter.
 func isASCIILetter(r rune) bool {
-	return r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z'
+	return 'a' <= r && r <= 'z' || 'A' <= r && r <= 'Z'
 }

--- a/graph/repo.go
+++ b/graph/repo.go
@@ -25,10 +25,24 @@ func MakeURI(cloneURL string) string {
 // "git://github.com/user/repo.git", to a normalized URI string, such
 // as "github.com/user/repo" lexically. TryMakeURI returns an error if
 // cloneURL is empty or malformed.
+// The following forms are supported
+// - transport://... (http://foo.bar)
+// - vcs:transport://... (hg:http://foo.bar)
+// - 'scm':vcs:transport://... (scm:git:git://foo.bar)
+// - user@host:path (assumed SSH)
+// - host:path (assumed SSH)
 func TryMakeURI(cloneURL string) (string, error) {
 	if cloneURL == "" {
 		return "", errors.New("MakeURI: empty clone URL")
 	}
+
+	// Removing leading "scm:" if any
+	if strings.HasPrefix(cloneURL, "scm:") {
+		cloneURL = cloneURL[4:]
+	}
+
+	// Removing VCS part if any, git:http://.. => http://..
+	cloneURL = removeVCSPart(cloneURL)
 
 	// Handle "user@host:path" and "host:path" (assumed SSH).
 	if strings.Contains(cloneURL, ":") && !strings.Contains(cloneURL, "://") {
@@ -58,4 +72,29 @@ func TryMakeURI(cloneURL string) (string, error) {
 // comparison (strings.EqualFold).
 func URIEqual(a, b string) bool {
 	return strings.EqualFold(a, b)
+}
+
+// Removes VCS part if any, git:http://.. => http://..
+func removeVCSPart(url string) string {
+	parts := strings.SplitN(url, ":", 3)
+	if len(parts) < 3 {
+		// does not look as foo:bar:...
+		return url
+	}
+	for _, r := range parts[0] {
+		if !isASCIILetter(r) {
+			return url
+		}
+	}
+	for _, r := range parts[1] {
+		if !isASCIILetter(r) {
+			return url
+		}
+	}
+	return parts[1] + ":" + parts[2]
+}
+
+// Returns true if given rune is ASCII letter
+func isASCIILetter(r rune) bool {
+	return r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z'
 }

--- a/graph/repo_test.go
+++ b/graph/repo_test.go
@@ -1,0 +1,54 @@
+package graph
+
+import "testing"
+
+// Ensures TryMakeURI works properly and supports different URLs
+func TestTryMakeURI(t *testing.T) {
+
+	tests := []struct {
+		source   string
+		expected string
+		error    bool
+	}{
+		{"http://sourcegraph.com/srclib", "sourcegraph.com/srclib", false},
+		{"git://sourcegraph.com/srclib", "sourcegraph.com/srclib", false},
+		{"hg://sourcegraph.com/srclib", "sourcegraph.com/srclib", false},
+		{"svn://sourcegraph.com/srclib", "sourcegraph.com/srclib", false},
+		{"ssh://sourcegraph.com/srclib", "sourcegraph.com/srclib", false},
+
+		{"scm:git:git://github.com/path_to_repository", "github.com/path_to_repository", false},
+		{"scm:git:http://github.com/path_to_repository", "github.com/path_to_repository", false},
+		{"scm:git:https://github.com/path_to_repository", "github.com/path_to_repository", false},
+		{"scm:git:ssh://github.com/path_to_repository", "github.com/path_to_repository", false},
+		{"scm:git:file://localhost/path_to_repository", "localhost/path_to_repository", false},
+
+		{"scm:hg:http://host/v3", "host/v3", false},
+		{"scm:hg:file://C:/dev/project/v3", "c:/dev/project/v3", false},
+		{"scm:hg:file:///home/smorgrav/dev/project/v3", "", true},
+		{"scm:hg:/home/smorgrav/dev/project/v3", "hg/home/smorgrav/dev/project/v3", false},
+
+		{"scm:svn:file:///svn/root/module", "", true},
+		{"scm:svn:file://localhost/path_to_repository", "localhost/path_to_repository", false},
+		{"scm:svn:file://my_server/path_to_repository", "my_server/path_to_repository", false},
+		{"scm:svn:http://svn.apache.org/svn/root/module", "svn.apache.org/svn/root/module", false},
+		{"scm:svn:https://username@svn.apache.org/svn/root/module", "svn.apache.org/svn/root/module", false},
+		{"scm:svn:https://username:password@svn.apache.org/svn/root/module", "svn.apache.org/svn/root/module", false},
+
+		{"scm:perforce://depot/modules/myproject", "depot/modules/myproject", false},
+		{"scm:perforce:host:path_to_repository", "host/path_to_repository", false},
+
+		{"user@host:path", "host/path", false},
+		{"host:path", "host/path", false},
+	}
+
+	for _, test := range tests {
+		actual, err := TryMakeURI(test.source)
+		if err != nil && !test.error {
+			t.Errorf("Got unexpected error %s on %s", err, test.source)
+		} else if err == nil && test.error {
+			t.Errorf("Expected to have an error on %s", test.source)
+		} else if actual != test.expected {
+			t.Errorf("Got `%s` while expected `%s`", actual, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
- adding SCM URL handling, now we should support the following URLs:
  - protocol:... (https://foo.bar)
  - vcs:... (git://foo.bar)
  - vcs:protocol:.... (git:https://foo.bar)
  - scm:vcs:protocol:... (scm:hg:https://foo.bar)
  - host:path (assumed SSH)