### PR TITLE
robust file-not-found check

### DIFF
--- a/cli/store_cmds.go
+++ b/cli/store_cmds.go
@@ -269,7 +269,8 @@ func Import(buildDataFS vfs.FileSystem, stor interface{}, opt ImportOpt) error {
 			case *grapher.GraphUnitRule:
 				var data graph.Output
 				if err := readJSONFileFS(buildDataFS, rule.Target(), &data); err != nil {
-					if os.IsNotExist(err) {
+					// checking if the error begins with "file not found" is necessary because the FS may not be the actual OS FS, in which case os.IsNotExist(err) == false
+					if os.IsNotExist(err) || strings.HasPrefix(err.Error(), "file not found:") {
 						log.Printf("Warning: no build data for unit %s %s.", rule.Unit.Type, rule.Unit.Name)
 						return nil
 					}


### PR DESCRIPTION
Sometimes, `buildDataFS` is a virtual FS (e.g., zipfs), in which case `os.IsNotExist(err) == false`.

This fixes an issue that causes the import step to fail completely in Sourcegraph if any file is not found (which happens frequently on larger repositories, where srclib might fail on some source units).