### PR TITLE
Windows support for 'srclib api'

### DIFF
--- a/cli/api_cmds.go
+++ b/cli/api_cmds.go
@@ -173,7 +173,7 @@ func prepareCommandContext(file string) (commandContext, error) {
 	if err != nil {
 		return commandContext{}, err
 	}
-	c.relativeFile = rel
+	c.relativeFile = filepath.ToSlash(rel)
 
 	if err := os.Chdir(repo.RootDir); err != nil {
 		return commandContext{}, err


### PR DESCRIPTION
- converting --file argument of `srclib api describe` and `srclib api list` to Unix-style