### PR TITLE
validate_cmd: not checking this error is causing a nil dereference.

### DIFF
--- a/cli/validate_cmd.go
+++ b/cli/validate_cmd.go
@@ -113,7 +113,10 @@ walkLoop:
 
 		pth := walker.Path()
 
-		if fi, err := os.Stat(pth); err != nil || !fi.IsDir() {
+		fi, err := os.Stat(pth)
+		if err != nil {
+			return err
+		} else if !fi.IsDir() {
 			continue
 		}
 

--- a/cli/validate_cmd.go
+++ b/cli/validate_cmd.go
@@ -113,8 +113,7 @@ walkLoop:
 
 		pth := walker.Path()
 
-		fi, err := os.Stat(pth)
-		if !fi.IsDir() {
+		if fi, err := os.Stat(pth); err != nil || !fi.IsDir() {
 			continue
 		}
 


### PR DESCRIPTION
@beyang 