### PR TITLE
cli: properly handle reading an empty json file

### DIFF
--- a/cli/coverage_cmd.go
+++ b/cli/coverage_cmd.go
@@ -126,6 +126,10 @@ func coverage(repo *Repo) (*cvg.Coverage, error) {
 
 		var data graph.Output
 		if err := readJSONFileFS(bdfs, rule.Target(), &data); err != nil {
+			if err == errEmptyJSONFile {
+				log.Printf("Warning: the JSON file is empty for unit %s %s.", rule.Unit.Type, rule.Unit.Name)
+				continue
+			}
 			if os.IsNotExist(err) {
 				log.Printf("Warning: no build data for unit %s %s.", rule.Unit.Type, rule.Unit.Name)
 				continue

--- a/cli/store_cmds.go
+++ b/cli/store_cmds.go
@@ -269,6 +269,10 @@ func Import(buildDataFS vfs.FileSystem, stor interface{}, opt ImportOpt) error {
 			case *grapher.GraphUnitRule:
 				var data graph.Output
 				if err := readJSONFileFS(buildDataFS, rule.Target(), &data); err != nil {
+					if err == errEmptyJSONFile {
+						log.Printf("Warning: the JSON file is empty for unit %s %s.", rule.Unit.Type, rule.Unit.Name)
+						return nil
+					}
 					if os.IsNotExist(err) {
 						log.Printf("Warning: no build data for unit %s %s.", rule.Unit.Type, rule.Unit.Name)
 						return nil

--- a/cli/util.go
+++ b/cli/util.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"math"
@@ -49,7 +50,16 @@ func PrintJSON(v interface{}, prefix string) {
 	colorable.Println(string(data))
 }
 
+var errEmptyJSONFile = errors.New("empty JSON file")
+
 func readJSONFile(file string, v interface{}) error {
+	fi, err := os.Stat(file)
+	if err != nil {
+		return err
+	}
+	if fi.Size() < 1 {
+		return errEmptyJSONFile
+	}
 	f, err := os.Open(file)
 	if err != nil {
 		return err
@@ -59,6 +69,13 @@ func readJSONFile(file string, v interface{}) error {
 }
 
 func readJSONFileFS(fs vfs.FileSystem, file string, v interface{}) (err error) {
+	fi, err := fs.Stat(file)
+	if err != nil {
+		return errEmptyJSONFile
+	}
+	if fi.Size() < 1 {
+		return nil
+	}
 	f, err := fs.Open(file)
 	if err != nil {
 		return err


### PR DESCRIPTION
This is related to srclib import failing with io.EOF errors while
reading a JSON file. An io.EOF file is thrown by the JSON decoder if it
is passed a io.Reader that immediately sends an io.EOF ( i.e. an empty
file ).

@beyang 