### PR TITLE
docs/install: elaborate on usage (store subcommands) + add zsh completion

### DIFF
--- a/contrib/completion/_srclib
+++ b/contrib/completion/_srclib
@@ -1,0 +1,7 @@
+#compdef srclib
+
+_srclib() {
+  compadd "$@" $(GO_FLAGS_COMPLETION=1 $words[0] "$words[@]")
+}
+
+_srclib

--- a/contrib/completion/srclib-completion.bash
+++ b/contrib/completion/srclib-completion.bash
@@ -4,7 +4,7 @@ _src() {
 	args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
 
 	local IFS=$'\n'
-	COMPREPLY=($(GO_FLAGS_COMPLETION=1 ${COMP_WORDS[0]} __complete -- "${args[@]}"))
+	COMPREPLY=($(GO_FLAGS_COMPLETION=1 ${COMP_WORDS[0]} "${args[@]}"))
 	return 1
 }
 

--- a/docs/sources/install.md
+++ b/docs/sources/install.md
@@ -65,9 +65,18 @@ git submodule update --init
 Now you can test the srclib-go toolchain with:
 
 ```
-srclib config && srclib make
+$ srclib do-all
+$ srclib store import
 ```
 
-You should have a .srclib-cache directory inside srclib-go that has all of the build data for the repository.
+You should have a .srclib-cache directory inside srclib-go that has all of the
+build data for the repository. You should also have a .srclib-store directory
+corresponding to the analysis information.
+
+```
+srclib store defs
+```
+
+should show you the definitions.
 
 <br>


### PR DESCRIPTION
.srclib-cache is fine, but we really need .srclib-store, which can be generated
using:

  $ srclib store import

Then, let's prompt the user to execute her first command that actually does
something with the data:

  $ srclib store defs

Also, add zsh completion.