### PR TITLE
fixing srclib sourcegraph link on homepage

### DIFF
--- a/docs/theme/home.html
+++ b/docs/theme/home.html
@@ -27,7 +27,7 @@
         href="#install"><button type="button" class="btn
         btn-default"><i class="fa fa-download"></i> Try it now</button></a>
         <a class="button-link" target="_blank"
-           href="https://sourcegraph.com/sourcegraph/srclib">
+           href="https://sourcegraph.com/github.com/sourcegraph/srclib">
           <button type="button" class="btn btn-default">&#x2731; Sourcegraph</button>
         </a>
         <a class="button-link" target="_blank" href="https://github.com/sourcegraph/srclib"><button type="button" class="btn btn-default"><i class="fa fa-github"></i> GitHub</button></a>


### PR DESCRIPTION
current link on srclib.org points to a 404 on sourcegraph.com 