### PR TITLE
graph: graph all GoPackage units together, for efficiency

### DIFF
--- a/cli/internal_data_cmds.go
+++ b/cli/internal_data_cmds.go
@@ -4,16 +4,24 @@ import (
 	"encoding/json"
 	"log"
 	"os"
+	"path/filepath"
 
 	"sourcegraph.com/sourcegraph/go-flags"
 
 	"sourcegraph.com/sourcegraph/srclib/graph"
 	"sourcegraph.com/sourcegraph/srclib/grapher"
+	"sourcegraph.com/sourcegraph/srclib/plan"
+	"sourcegraph.com/sourcegraph/srclib/unit"
 )
 
 func init() {
 	cliInit = append(cliInit, func(cli *flags.Command) {
 		c, err := cli.AddCommand("internal", "(internal subcommands - do not use)", "Internal subcommands. Do not use.", &struct{}{})
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		_, err = c.AddCommand("emit-unit-data", "", "", &emitUnitDataCmd)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -25,9 +33,41 @@ func init() {
 	})
 }
 
+type EmitUnitDataCmd struct {
+	Args struct {
+		Units []string `name:"units" description:"Paths to source units."`
+	} `positional-args:"yes"`
+}
+
+var emitUnitDataCmd EmitUnitDataCmd
+
+func (c *EmitUnitDataCmd) Execute(args []string) error {
+	var units unit.SourceUnits
+
+	for _, path := range c.Args.Units {
+		unitFile, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		var u *unit.SourceUnit
+		if err := json.NewDecoder(unitFile).Decode(&u); err != nil {
+			return err
+		}
+		units = append(units, u)
+	}
+
+	if err := json.NewEncoder(os.Stdout).Encode(units); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 type NormalizeGraphDataCmd struct {
 	UnitType string `long:"unit-type" description:"source unit type (e.g., GoPackage)"`
 	Dir      string `long:"dir" description:"directory of source unit (SourceUnit.Dir field)"`
+	Multi    bool   `long:"multi" description:"the input contains graph data for multiple units; output will be split into different files per source unit"`
+	DataDir  string `long:"data-dir" description:"output data dir"`
 }
 
 var normalizeGraphDataCmd NormalizeGraphDataCmd
@@ -44,13 +84,76 @@ func (c *NormalizeGraphDataCmd) Execute(args []string) error {
 		return err
 	}
 
-	data, err := json.MarshalIndent(o, "", "  ")
-	if err != nil {
-		return err
+	if !c.Multi {
+		data, err := json.MarshalIndent(o, "", "  ")
+		if err != nil {
+			return err
+		}
+
+		if _, err := os.Stdout.Write(data); err != nil {
+			return err
+		}
 	}
 
-	if _, err := os.Stdout.Write(data); err != nil {
-		return err
+	// graphPerUnit maps source unit names to the graph data of
+	// that unit.
+	graphPerUnit := make(map[string]*graph.Output)
+	initUnitGraph := func(unitName string) {
+		if _, ok := graphPerUnit[unitName]; !ok {
+			graphPerUnit[unitName] = &graph.Output{}
+		}
+	}
+
+	// Split the graph data per source unit.
+	for _, d := range o.Defs {
+		if d.Unit == "" {
+			log.Printf("skip def with empty unit: %v", d)
+			continue
+		}
+		initUnitGraph(d.Unit)
+		graphPerUnit[d.Unit].Defs = append(graphPerUnit[d.Unit].Defs, d)
+	}
+	for _, r := range o.Refs {
+		if r.Unit == "" {
+			log.Printf("skip ref with empty unit: %v", r)
+			continue
+		}
+		initUnitGraph(r.Unit)
+		graphPerUnit[r.Unit].Refs = append(graphPerUnit[r.Unit].Refs, r)
+	}
+	for _, d := range o.Docs {
+		if d.DocUnit == "" {
+			log.Printf("skip doc with empty unit: %v", d)
+			continue
+		}
+		initUnitGraph(d.DocUnit)
+		graphPerUnit[d.DocUnit].Docs = append(graphPerUnit[d.DocUnit].Docs, d)
+	}
+	for _, a := range o.Anns {
+		if a.Unit == "" {
+			log.Printf("skip ann with empty unit: %v", a)
+			continue
+		}
+		initUnitGraph(a.Unit)
+		graphPerUnit[a.Unit].Anns = append(graphPerUnit[a.Unit].Anns, a)
+	}
+
+	// Write the graph data to a separate file for each source unit.
+	for unitName, graphData := range graphPerUnit {
+		path := filepath.ToSlash(filepath.Join(c.DataDir, plan.SourceUnitDataFilename(&graph.Output{}, &unit.SourceUnit{Name: unitName, Type: c.UnitType})))
+		graphFile, err := os.Create(path)
+		if err != nil {
+			return err
+		}
+
+		data, err := json.MarshalIndent(graphData, "", "  ")
+		if err != nil {
+			return err
+		}
+
+		if _, err := graphFile.Write(data); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cli/store_cmds.go
+++ b/cli/store_cmds.go
@@ -239,10 +239,63 @@ func Import(buildDataFS vfs.FileSystem, stor interface{}, opt ImportOpt) error {
 		return fmt.Errorf("error calling plan.Makefile: %s", err)
 	}
 
-	var (
-		mu               sync.Mutex
-		hasIndexableData bool
-	)
+	// hasIndexableData is set if at least one source unit's graph data is
+	// successfully imported to the graph store.
+	//
+	// This flag is set concurrently in calls to importGraphData, but it doesn't
+	// need to be protected by a mutex since its value is only modified in one
+	// direction (false to true), and it is only read in the sequential section
+	// after parallel.NewRun completes.
+	var hasIndexableData bool
+
+	importGraphData := func(graphFile string, sourceUnit *unit.SourceUnit) error {
+		var data graph.Output
+		if err := readJSONFileFS(buildDataFS, graphFile, &data); err != nil {
+			if err == errEmptyJSONFile {
+				log.Printf("Warning: the JSON file is empty for unit %s %s.", sourceUnit.Type, sourceUnit.Name)
+				return nil
+			}
+			if os.IsNotExist(err) {
+				log.Printf("Warning: no build data for unit %s %s.", sourceUnit.Type, sourceUnit.Name)
+				return nil
+			}
+			return fmt.Errorf("error reading JSON file %s for unit %s %s: %s", graphFile, sourceUnit.Type, sourceUnit.Name, err)
+		}
+		if opt.DryRun || GlobalOpt.Verbose {
+			log.Printf("# Importing graph data (%d defs, %d refs, %d docs, %d anns) for unit %s %s", len(data.Defs), len(data.Refs), len(data.Docs), len(data.Anns), sourceUnit.Type, sourceUnit.Name)
+			if opt.DryRun {
+				return nil
+			}
+		}
+
+		// HACK: Transfer docs to [def].Docs.
+		docsByPath := make(map[string]*graph.Doc, len(data.Docs))
+		for _, doc := range data.Docs {
+			docsByPath[doc.Path] = doc
+		}
+		for _, def := range data.Defs {
+			if doc, present := docsByPath[def.Path]; present {
+				def.Docs = append(def.Docs, &graph.DefDoc{Format: doc.Format, Data: doc.Data})
+			}
+		}
+
+		switch imp := stor.(type) {
+		case store.RepoImporter:
+			if err := imp.Import(opt.CommitID, sourceUnit, data); err != nil {
+				return fmt.Errorf("error running store.RepoImporter.Import: %s", err)
+			}
+		case store.MultiRepoImporter:
+			if err := imp.Import(opt.Repo, opt.CommitID, sourceUnit, data); err != nil {
+				return fmt.Errorf("error running store.MultiRepoImporter.Import: %s", err)
+			}
+		default:
+			return fmt.Errorf("store (type %T) does not implement importing", stor)
+		}
+
+		hasIndexableData = true
+
+		return nil
+	}
 
 	par := parallel.NewRun(10)
 	for _, rule_ := range mf.Rules {
@@ -267,52 +320,16 @@ func Import(buildDataFS vfs.FileSystem, stor interface{}, opt ImportOpt) error {
 		par.Do(func() error {
 			switch rule := rule.(type) {
 			case *grapher.GraphUnitRule:
-				var data graph.Output
-				if err := readJSONFileFS(buildDataFS, rule.Target(), &data); err != nil {
-					if err == errEmptyJSONFile {
-						log.Printf("Warning: the JSON file is empty for unit %s %s.", rule.Unit.Type, rule.Unit.Name)
-						return nil
+				return importGraphData(rule.Target(), rule.Unit)
+			case *grapher.GraphMultiUnitsRule:
+				for target, sourceUnit := range rule.Targets() {
+					if (opt.Unit != "" && sourceUnit.Name != opt.Unit) || (opt.UnitType != "" && sourceUnit.Type != opt.UnitType) {
+						continue
 					}
-					if os.IsNotExist(err) {
-						log.Printf("Warning: no build data for unit %s %s.", rule.Unit.Type, rule.Unit.Name)
-						return nil
-					}
-					return fmt.Errorf("error reading JSON file %s for unit %s %s: %s", rule.Target(), rule.Unit.Type, rule.Unit.Name, err)
-				}
-				if opt.DryRun || GlobalOpt.Verbose {
-					log.Printf("# Importing graph data (%d defs, %d refs, %d docs, %d anns) for unit %s %s", len(data.Defs), len(data.Refs), len(data.Docs), len(data.Anns), rule.Unit.Type, rule.Unit.Name)
-					if opt.DryRun {
-						return nil
+					if err := importGraphData(target, sourceUnit); err != nil {
+						return err
 					}
 				}
-
-				// HACK: Transfer docs to [def].Docs.
-				docsByPath := make(map[string]*graph.Doc, len(data.Docs))
-				for _, doc := range data.Docs {
-					docsByPath[doc.Path] = doc
-				}
-				for _, def := range data.Defs {
-					if doc, present := docsByPath[def.Path]; present {
-						def.Docs = append(def.Docs, &graph.DefDoc{Format: doc.Format, Data: doc.Data})
-					}
-				}
-
-				switch imp := stor.(type) {
-				case store.RepoImporter:
-					if err := imp.Import(opt.CommitID, rule.Unit, data); err != nil {
-						return fmt.Errorf("error running store.RepoImporter.Import: %s", err)
-					}
-				case store.MultiRepoImporter:
-					if err := imp.Import(opt.Repo, opt.CommitID, rule.Unit, data); err != nil {
-						return fmt.Errorf("error running store.MultiRepoImporter.Import: %s", err)
-					}
-				default:
-					return fmt.Errorf("store (type %T) does not implement importing", stor)
-				}
-
-				mu.Lock()
-				hasIndexableData = true
-				mu.Unlock()
 			}
 			return nil
 		})

--- a/graph/doc.pb.go
+++ b/graph/doc.pb.go
@@ -33,6 +33,8 @@ type Doc struct {
 	Start uint32 `protobuf:"varint,5,opt,name=Start,proto3" json:"Start,omitempty"`
 	// End is the byte offset of this Doc's last byte in File.
 	End uint32 `protobuf:"varint,6,opt,name=End,proto3" json:"End,omitempty"`
+	// DocUnit is the source unit containing this Doc.
+	DocUnit string `protobuf:"bytes,7,opt,name=DocUnit,proto3" json:"DocUnit,omitempty"`
 }
 
 func (m *Doc) Reset()         { *m = Doc{} }
@@ -90,6 +92,12 @@ func (m *Doc) MarshalTo(data []byte) (int, error) {
 		i++
 		i = encodeVarintDoc(data, i, uint64(m.End))
 	}
+	if len(m.DocUnit) > 0 {
+		data[i] = 0x3a
+		i++
+		i = encodeVarintDoc(data, i, uint64(len(m.DocUnit)))
+		i += copy(data[i:], m.DocUnit)
+	}
 	return i, nil
 }
 
@@ -142,6 +150,10 @@ func (m *Doc) Size() (n int) {
 	}
 	if m.End != 0 {
 		n += 1 + sovDoc(uint64(m.End))
+	}
+	l = len(m.DocUnit)
+	if l > 0 {
+		n += 1 + l + sovDoc(uint64(l))
 	}
 	return n
 }
@@ -343,6 +355,35 @@ func (m *Doc) Unmarshal(data []byte) error {
 					break
 				}
 			}
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DocUnit", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDoc
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthDoc
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DocUnit = string(data[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipDoc(data[iNdEx:])

--- a/graph/doc.proto
+++ b/graph/doc.proto
@@ -30,4 +30,7 @@ message Doc {
 
     // End is the byte offset of this Doc's last byte in File.
     uint32 End = 6 [(gogoproto.jsontag) = "End,omitempty"];
+
+    // DocUnit is the source unit containing this Doc.
+    string DocUnit = 7 [(gogoproto.jsontag) = "DocUnit,omitempty"];
 };

--- a/grapher/rule.go
+++ b/grapher/rule.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"sourcegraph.com/sourcegraph/makex"
 	"sourcegraph.com/sourcegraph/srclib"
@@ -17,9 +18,11 @@ import (
 )
 
 const graphOp = "graph"
+const graphAllOp = "graph-all"
 
 func init() {
 	plan.RegisterRuleMaker(graphOp, makeGraphRules)
+	plan.RegisterRuleMaker(graphAllOp, makeGraphAllRules)
 	buildstore.RegisterDataType("graph", &graph.Output{})
 }
 
@@ -27,7 +30,10 @@ func makeGraphRules(c *config.Tree, dataDir string, existing []makex.Rule) ([]ma
 	const op = graphOp
 	var rules []makex.Rule
 	for _, u := range c.SourceUnits {
-		toolRef := u.Ops[op]
+		toolRef, ok := u.Ops[op]
+		if !ok {
+			continue
+		}
 		if toolRef == nil {
 			choice, err := toolchain.ChooseTool(graphOp, u.Type)
 			if err != nil {
@@ -37,6 +43,31 @@ func makeGraphRules(c *config.Tree, dataDir string, existing []makex.Rule) ([]ma
 		}
 
 		rules = append(rules, &GraphUnitRule{dataDir, u, toolRef})
+	}
+	return rules, nil
+}
+
+func makeGraphAllRules(c *config.Tree, dataDir string, existing []makex.Rule) ([]makex.Rule, error) {
+	const op = graphAllOp
+
+	// Group all graph-all units by type.
+	groupedUnits := make(map[string]unit.SourceUnits)
+	for _, u := range c.SourceUnits {
+		if _, ok := u.Ops[op]; !ok {
+			continue
+		}
+
+		groupedUnits[u.Type] = append(groupedUnits[u.Type], u)
+	}
+
+	// Make a GraphMultiUnitsRule for each group of source units
+	var rules []makex.Rule
+	for unitType, units := range groupedUnits {
+		toolRef, err := toolchain.ChooseTool(graphOp, unitType)
+		if err != nil {
+			return nil, err
+		}
+		rules = append(rules, &GraphMultiUnitsRule{dataDir, units, unitType, toolRef})
 	}
 	return rules, nil
 }
@@ -74,3 +105,55 @@ func (r *GraphUnitRule) Recipes() []string {
 }
 
 func (r *GraphUnitRule) SourceUnit() *unit.SourceUnit { return r.Unit }
+
+type GraphMultiUnitsRule struct {
+	dataDir   string
+	Units     unit.SourceUnits
+	UnitsType string
+	Tool      *srclib.ToolRef
+}
+
+func (r *GraphMultiUnitsRule) Target() string {
+	// This is a dummy target, which is only used for ensuring a stable ordering of
+	// the makefile rules (see plan/util.go). Both import command and coverage command
+	// call the Targets() method to get the *.graph.json filepaths for all units graphed
+	// by this rule.
+	return filepath.ToSlash(filepath.Join(r.dataDir, plan.SourceUnitDataFilename(&graph.Output{}, &unit.SourceUnit{Type: r.UnitsType})))
+}
+
+func (r *GraphMultiUnitsRule) Targets() map[string]*unit.SourceUnit {
+	var targets map[string]*unit.SourceUnit
+	for _, u := range r.Units {
+		targets[filepath.ToSlash(filepath.Join(r.dataDir, plan.SourceUnitDataFilename(&graph.Output{}, u)))] = u
+	}
+	return targets
+}
+
+func (r *GraphMultiUnitsRule) Prereqs() []string {
+	ps := []string{}
+	for _, u := range r.Units {
+		ps = append(ps, filepath.ToSlash(filepath.Join(r.dataDir, plan.SourceUnitDataFilename(unit.SourceUnit{}, u))))
+		for _, file := range u.Files {
+			if _, err := os.Stat(file); err != nil && os.IsNotExist(err) {
+				// skip not-existent files listed in source unit
+				continue
+			}
+			ps = append(ps, file)
+		}
+	}
+	return ps
+}
+
+func (r *GraphMultiUnitsRule) Recipes() []string {
+	if r.Tool == nil {
+		return nil
+	}
+	safeCommand := util.SafeCommandName(srclib.CommandName)
+	unitFiles := []string{}
+	for _, u := range r.Units {
+		unitFiles = append(unitFiles, filepath.ToSlash(filepath.Join(r.dataDir, plan.SourceUnitDataFilename(unit.SourceUnit{}, u))))
+	}
+	return []string{
+		fmt.Sprintf("%s internal emit-unit-data %s | %s tool %q %q | %s internal normalize-graph-data --unit-type %q --dir . --multi --data-dir %s", safeCommand, strings.Join(unitFiles, " "), safeCommand, r.Tool.Toolchain, r.Tool.Subcmd, safeCommand, r.UnitsType, r.dataDir),
+	}
+}

--- a/plan/data.go
+++ b/plan/data.go
@@ -12,5 +12,8 @@ func RepositoryCommitDataFilename(emptyData interface{}) string {
 }
 
 func SourceUnitDataFilename(emptyData interface{}, u *unit.SourceUnit) string {
+	if u.Name == "" {
+		return u.Type + "." + buildstore.DataTypeSuffix(emptyData)
+	}
 	return filepath.Join(u.Name, u.Type+"."+buildstore.DataTypeSuffix(emptyData))
 }


### PR DESCRIPTION
Depends on https://github.com/sourcegraph/srclib-go/pull/78

This uses the updated srclib-go grapher API to graph all GoPackage
units in the repo in a single call to srclib-go. This avoids the
duplicate work done to load and parse dependencies of the Go packages.

The GraphMultiUnitsRule rule will output a single GoPackage.graph.json
for the entire repo, with all defs, refs and docs in a single json file.

Observed 10x reduction in total CPU time used for building sourcegraph/sourcegraph
repo in local testing.

TODO: modify cli.Import to handle GraphMultiUnitsRule. This might be simplified
with the graph store redesign.