### PR TITLE
`srclib coverage` improvements

### DIFF
--- a/cli/coverage_test.go
+++ b/cli/coverage_test.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"testing"
+)
+
+func TestNumLines(t *testing.T) {
+	tests := []struct {
+		data     string
+		expected int
+	}{
+		{
+			"do\ncats\neat\nbats",
+			4,
+		},
+		{
+			"do\n\n\n\ncats\neat\nbats",
+			4,
+		},
+		{
+			"do\r\n\r\n\r\ncats\neat\nbats",
+			4,
+		},
+		{
+			"",
+			0,
+		},
+		{
+			"abc\n//def\nfgh",
+			2,
+		},
+	}
+
+	for _, test := range tests {
+		actual := numLines([]byte(test.data))
+		if actual != test.expected {
+			t.Errorf("%s, got %v, want %v", test.data, actual, test.expected)
+		}
+	}
+
+}


### PR DESCRIPTION
- when computing density, excluding blank and commented out lines (assuming that comment starts with //)
- when processing repository with multiple units, collecting all definitions before looking for them in the references. Otherwise we may found no definition if it was defined in a different unit
- using {unit, unit type, path} when matching refs to defs; normalizing ref.DefKey and def.DefKey objects before matching them. This is done to prevent cache misses when ref points to definition from the other unit (def has no unit/unittype set while ref includes not-empty defunit/defunitype)
- Windows support (using slashes as separators)