### PR TITLE
`srclib coverage` improvements

### DIFF
--- a/cli/coverage_test.go
+++ b/cli/coverage_test.go
@@ -1,8 +1,30 @@
 package cli
 
 import (
+	"io/ioutil"
 	"testing"
 )
+
+func TestStripComments(t *testing.T) {
+
+	source, _ := ioutil.ReadFile("testdata/strip-comments/commented-source.txt")
+	target, _ := ioutil.ReadFile("testdata/strip-comments/expected-source.txt")
+	expected := string(target)
+
+	actual := string(stripComments(source))
+	if actual != expected {
+		t.Errorf("got\n%v\n, want\n%v\n", actual, expected)
+	}
+
+	source = []byte("abc\n//def\nfgh")
+	expected = "abc\n\nfgh"
+
+	actual = string(stripComments(source))
+	if actual != expected {
+		t.Errorf("got\n%v\n, want\n%v\n", actual, expected)
+	}
+
+}
 
 func TestNumLines(t *testing.T) {
 	tests := []struct {
@@ -28,6 +50,10 @@ func TestNumLines(t *testing.T) {
 		{
 			"abc\n//def\nfgh",
 			2,
+		},
+		{
+			"",
+			0,
 		},
 	}
 

--- a/cli/testdata/strip-comments/commented-source.txt
+++ b/cli/testdata/strip-comments/commented-source.txt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package retrofit2.http;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import okhttp3.HttpUrl;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/** Make a DELETE request. */
+@Documented
+@Target(METHOD)
+@Retention(RUNTIME)
+public @interface DELETE {
+  /**
+   * A relative or absolute path, or full URL of the endpoint. This value is optional if the first
+   * parameter of the method is annotated with {@link Url @Url}.
+   * <p>
+   * See {@linkplain retrofit2.Retrofit.Builder#baseUrl(HttpUrl) base URL} for details of how
+   * this is resolved against a base URL to create the full endpoint URL.
+   */
+  String value() default "";
+}

--- a/cli/testdata/strip-comments/expected-source.txt
+++ b/cli/testdata/strip-comments/expected-source.txt
@@ -1,0 +1,19 @@
+
+package retrofit2.http;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import okhttp3.HttpUrl;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+
+@Documented
+@Target(METHOD)
+@Retention(RUNTIME)
+public @interface DELETE {
+  
+  String value() default "";
+}


### PR DESCRIPTION
- excluding comments when counting lines of code, otherwise small thoroughly commented file (usually with the large copyright or license information) may be considered 'uncovered'