### PR TITLE
Introduced SkipScan Srcfile's flag

### DIFF
--- a/cli/units_cmd.go
+++ b/cli/units_cmd.go
@@ -32,16 +32,8 @@ func init() {
 // cfg.SourceUnits, merging the scanned source units with those already present
 // in cfg.
 func scanUnitsIntoConfig(cfg *config.Repository, quiet bool) error {
-	scanners := make([][]string, len(cfg.Scanners))
-	for i, scannerRef := range cfg.Scanners {
-		cmdName, err := toolchain.Command(scannerRef.Toolchain)
-		if err != nil {
-			return err
-		}
-		scanners[i] = []string{cmdName, scannerRef.Subcmd}
-	}
 
-	units, err := scan.ScanMulti(scanners, scan.Options{Quiet: quiet}, cfg.Config)
+	units, err := runScanners(cfg, quiet)
 	if err != nil {
 		return err
 	}
@@ -107,6 +99,26 @@ func scanUnitsIntoConfig(cfg *config.Repository, quiet bool) error {
 	}
 
 	return nil
+}
+
+// runScanners returns no units if configuration set SkipScan, otherwise runs
+// all the scanners to retrieve source units
+func runScanners(cfg *config.Repository, quiet bool) ([]*unit.SourceUnit, error) {
+
+	if cfg.SkipScan {
+		return []*unit.SourceUnit{}, nil
+	}
+
+	scanners := make([][]string, len(cfg.Scanners))
+	for i, scannerRef := range cfg.Scanners {
+		cmdName, err := toolchain.Command(scannerRef.Toolchain)
+		if err != nil {
+			return nil, err
+		}
+		scanners[i] = []string{cmdName, scannerRef.Subcmd}
+	}
+
+	return scan.ScanMulti(scanners, scan.Options{Quiet: quiet}, cfg.Config)
 }
 
 type UnitsCmd struct {

--- a/config/config.go
+++ b/config/config.go
@@ -47,6 +47,10 @@ type Tree struct {
 	// Config is an arbitrary key-value property map. Properties are copied
 	// verbatim to each source unit that is scanned in this tree.
 	Config map[string]interface{} `json:",omitempty"`
+
+	// SkipScan indicates if we should skip scan phase assuming that everything
+	// is pre-configured
+	SkipScan bool `json:",omitempty"`
 }
 
 // ReadRepository parses and validates the configuration for a repository. If no


### PR DESCRIPTION
- introducing new flag SkipScan of Srcfile that may disable 'scan' phase execution (assumed that Srcfile contains all the source units and there is no need to scan for extra)