### PR TITLE
Change srclib metadata import to write new refs/defs/indexes in serial.

### DIFF
--- a/store/indexed.go
+++ b/store/indexed.go
@@ -596,22 +596,20 @@ func (s *indexedUnitStore) Import(data graph.Output) error {
 	var defOfs, refOfs byteOffsets
 	var refFBRs fileByteRanges
 
-	par := parallel.NewRun(2)
-	par.Do(func() (err error) {
-		defOfs, err = s.fsUnitStore.writeDefs(data.Defs)
-		return err
-	})
-	par.Do(func() (err error) {
-		refFBRs, refOfs, err = s.fsUnitStore.writeRefs(data.Refs)
-		return err
-	})
-	if err := par.Wait(); err != nil {
+	//Complete each write operation serially which eliminates
+	//a lock contention bug on slower underlying file stores
+	defOfs, err = s.fsUnitStore.writeDefs(data.Defs)
+	if err != nil {
 		return err
 	}
-
+	refFBRs, refOfs, err = s.fsUnitStore.writeRefs(data.Refs)
+	if err != nil {
+		return err
+	}
 	if err := s.buildIndexes(s.Indexes(), &data, defOfs, refFBRs, refOfs); err != nil {
 		return err
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
This change removes the parallel writes that were in place previously.
This is only a change at the source unit level, multiple source units can still be stored in parallel, but this
change makes the writes atomic within a single source unit.  In theory the old parallel writes should have made import faster, but on slower storage systems, this was causing write contention and data
corruption, slowing things way down.  Serial writes eliminate this corruption. 