### PR TITLE
Fix concurrency issues in import step

### DIFF
--- a/cli/store_cmds.go
+++ b/cli/store_cmds.go
@@ -246,7 +246,13 @@ func Import(buildDataFS vfs.FileSystem, stor interface{}, opt ImportOpt) error {
 	// need to be protected by a mutex since its value is only modified in one
 	// direction (false to true), and it is only read in the sequential section
 	// after parallel.NewRun completes.
-	var hasIndexableData bool
+	//
+	// However, we still protect it with a mutex to avoid data race errors from the
+	// Go race detector.
+	var (
+		mu               sync.Mutex
+		hasIndexableData bool
+	)
 
 	importGraphData := func(graphFile string, sourceUnit *unit.SourceUnit) error {
 		var data graph.Output
@@ -292,7 +298,9 @@ func Import(buildDataFS vfs.FileSystem, stor interface{}, opt ImportOpt) error {
 			return fmt.Errorf("store (type %T) does not implement importing", stor)
 		}
 
+		mu.Lock()
 		hasIndexableData = true
+		mu.Unlock()
 
 		return nil
 	}

--- a/cli/store_cmds.go
+++ b/cli/store_cmds.go
@@ -309,7 +309,8 @@ func Import(buildDataFS vfs.FileSystem, stor interface{}, opt ImportOpt) error {
 				return importGraphData(rule.Target(), rule.Unit)
 			})
 		case *grapher.GraphMultiUnitsRule:
-			for target, sourceUnit := range rule.Targets() {
+			for target_, sourceUnit_ := range rule.Targets() {
+				target, sourceUnit := target_, sourceUnit_
 				if (opt.Unit != "" && sourceUnit.Name != opt.Unit) || (opt.UnitType != "" && sourceUnit.Type != opt.UnitType) {
 					continue
 				}


### PR DESCRIPTION
This PR fixes two issues that were recently introduced with the `GraphMultiUnitsRule`:

1. Protect the shared variable `hasIndexableData` with a mutex to avoid Go race detector from complaining.

2. Use proper closure for concurrent to `importGraphData` calls within for loop. This issue would cause the graph data for certain units from never getting imported, while certain other units would be imported multiple times, within the same build.