### PR TITLE
Restored Windows support for Go toolchain

### DIFF
--- a/cli/toolchain_cmd.go
+++ b/cli/toolchain_cmd.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"runtime"
 
 	"strings"
 
@@ -267,7 +268,7 @@ var stdToolchains = toolchainMap{
 
 func (m toolchainMap) listKeys() string {
 	var langs string
-	for i, _ := range m {
+	for i := range m {
 		langs += i + ", "
 	}
 	// Remove the last comma from langs before returning it.
@@ -331,11 +332,6 @@ run this command again.`)
 	if os.Getenv("GOPATH") == "" {
 		os.Setenv("GOPATH", path.Join(util.CurrentUserHomeDir(), ".srclib-gopath"))
 	}
-	// Add symlink to GOPATH so install succeeds (necessary as long as there's a Go dependency in this toolchain)
-	err, gopathDir := symlinkToGopath(toolchain)
-	if err != nil {
-		return err
-	}
 
 	srclibpathDir := filepath.Join(filepath.SplitList(srclib.Path)[0], toolchain) // toolchain dir under SRCLIBPATH
 	if err := os.MkdirAll(filepath.Dir(srclibpathDir), 0700); err != nil {
@@ -344,6 +340,12 @@ run this command again.`)
 
 	log.Println("Downloading Go toolchain")
 	if err := cloneToolchain(srclibpathDir, toolchain); err != nil {
+		return err
+	}
+
+	// Add symlink to GOPATH so install succeeds (necessary as long as there's a Go dependency in this toolchain)
+	err, gopathDir := symlinkToGopath(toolchain)
+	if err != nil {
 		return err
 	}
 
@@ -612,9 +614,15 @@ func symlinkToGopath(toolchain string) (err error, gopathDir string) {
 		if err := os.MkdirAll(filepath.Dir(gopathDir), 0700); err != nil {
 			return err, ""
 		}
-		log.Printf("ln -s %s %s", srclibpathDir, gopathDir)
-		if err := os.Symlink(srclibpathDir, gopathDir); err != nil {
-			return err, ""
+		if runtime.GOOS != "windows" {
+			log.Printf("ln -s %s %s", srclibpathDir, gopathDir)
+			if err := os.Symlink(srclibpathDir, gopathDir); err != nil {
+				return err, ""
+			}
+		} else {
+			if err := execCmdInDir(srclibpathDir, "cmd", "/c", "mklink", "/D", gopathDir, srclibpathDir); err != nil {
+				return err, ""
+			}
 		}
 	} else if err != nil {
 		return err, ""

--- a/cli/toolchain_cmd.go
+++ b/cli/toolchain_cmd.go
@@ -620,6 +620,9 @@ func symlinkToGopath(toolchain string) (err error, gopathDir string) {
 				return err, ""
 			}
 		} else {
+			// os.Symlink makes "file symbolic link" on Windows making impossible to install Go toolchain
+			// because `cd foo && make` requires "foo" to be either a directory or so-called "directory symbolic link".
+			// That's why we had to use `mklink /D bar foo`
 			if err := execCmdInDir(srclibpathDir, "cmd", "/c", "mklink", "/D", gopathDir, srclibpathDir); err != nil {
 				return err, ""
 			}

--- a/grapher/rule.go
+++ b/grapher/rule.go
@@ -151,6 +151,6 @@ func (r *GraphMultiUnitsRule) Recipes() []string {
 		unitFiles = append(unitFiles, filepath.ToSlash(filepath.Join(r.dataDir, plan.SourceUnitDataFilename(unit.SourceUnit{}, u))))
 	}
 	return []string{
-		fmt.Sprintf("%s internal emit-unit-data %s | %s tool %q %q | %s internal normalize-graph-data --unit-type %q --dir . --multi --data-dir %s", safeCommand, strings.Join(unitFiles, " "), safeCommand, r.Tool.Toolchain, r.Tool.Subcmd, safeCommand, r.UnitsType, r.dataDir),
+		fmt.Sprintf("%s internal emit-unit-data %s | %s tool %q %q | %s internal normalize-graph-data --unit-type %q --dir . --multi --data-dir %s", safeCommand, strings.Join(unitFiles, " "), safeCommand, r.Tool.Toolchain, r.Tool.Subcmd, safeCommand, r.UnitsType, filepath.ToSlash(r.dataDir)),
 	}
 }


### PR DESCRIPTION
- `os.Symlink` makes "file-type" symbolic links on Windows while `cd foo && make` requires "foo" to be either directory or so-called "directory symbolic link". This was the reason that  it was impossible to install go toolchain on Windows because attempt to execute `make` in file-type symbolic link failed. I also had to change execution order from (symlink, clone) to (clone, symlink) when installing Go toolchain
- thou shall not emit backslashes when generating Makefile commands, they being cut making command not runnable