### PR TITLE
Adding .PHONY target

### DIFF
--- a/plan/makefile.go
+++ b/plan/makefile.go
@@ -45,13 +45,17 @@ func CreateMakefile(buildDataDir string, buildStore buildstore.RepoBuildStore, v
 		allRules = append(allRules, rules...)
 	}
 
-	// Add an "all" rule at the very beginning.
+	// Add a ".PHONY" and "all" rules at the very beginning.
 	allTargets := make([]string, len(allRules))
 	for i, rule := range allRules {
 		allTargets[i] = rule.Target()
 	}
+
 	allRule := &makex.BasicRule{TargetFile: "all", PrereqFiles: allTargets}
 	allRules = append([]makex.Rule{allRule}, allRules...)
+
+	phonyRule := &makex.BasicRule{TargetFile: ".PHONY", PrereqFiles: []string{"all"}}
+	allRules = append([]makex.Rule{phonyRule}, allRules...)
 
 	// DELETE_ON_ERROR makes it so that the targets for failed recipes are
 	// deleted. This lets us do "1> $@" to write to the target file without

--- a/plan/makefile_test.go
+++ b/plan/makefile_test.go
@@ -37,6 +37,8 @@ func TestCreateMakefile(t *testing.T) {
 	}
 
 	want := `
+.PHONY: all
+
 all: testdata/n/t.depresolve.json testdata/n/t.graph.json
 
 testdata/n/t.depresolve.json: testdata/n/t.unit.json

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -295,10 +295,10 @@
 			"revisionTime": "2015-12-22T00:11:22-08:00"
 		},
 		{
-			"checksumSHA1": "Vlm8qSVEjGavwRiorny9xJsFJBk=",
+			"checksumSHA1": "i/xlef6YYvqTCApzwaitRbA7hqM=",
 			"path": "sourcegraph.com/sourcegraph/makex",
-			"revision": "9a03b093bc189b7f30af07076ff81a309d8c7621",
-			"revisionTime": "2015-12-12T22:14:40-08:00"
+			"revision": "ebd8626d42863f226f97c369cef6a989f410ac7b",
+			"revisionTime": "2016-04-25T10:05:24+03:00"
 		},
 		{
 			"checksumSHA1": "YGx0MAcypbYRZkpImuY6iY/zpR8=",


### PR DESCRIPTION
- adding .PHONY target to generated makefile to ensure that "all" target does not clash with file names. See sourcegraph/makex#2
- updated vendored sourcegraph.com/sourcegraph/makex