### PR TITLE
Fixed installation of javascript toolchain

### DIFF
--- a/cli/toolchain_cmd.go
+++ b/cli/toolchain_cmd.go
@@ -397,7 +397,7 @@ func installRubyToolchain() error {
 }
 
 func installJavaScriptToolchain() error {
-	const toolchain = "sourcegraph.com/sourcegraph/srclib-javascript"
+	const toolchain = "github.com/sourcegraph/srclib-javascript"
 
 	srclibpathDir := filepath.Join(filepath.SplitList(srclib.Path)[0], toolchain) // toolchain dir under SRCLIBPATH
 

--- a/cli/toolchain_cmd.go
+++ b/cli/toolchain_cmd.go
@@ -413,6 +413,11 @@ func installJavaScriptToolchain() error {
 		return err
 	}
 
+	log.Println("Building JavaScript toolchain program")
+	if err := execCmdInDir(srclibpathDir, "npm", "install"); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
- added 'npm install' to javascript toolchain installation steps, required since sourcegraph/srclib-javascript@06d640c18edff4d78d9abad63a07c08f02e68c22)