### PR TITLE
Improved coverage calculation, support of URL with empty path, fixed C# toolchain installation

### DIFF
--- a/cli/toolchain_cmd.go
+++ b/cli/toolchain_cmd.go
@@ -553,7 +553,7 @@ func installCSharpToolchain() error {
 
 	nugetdir := filepath.Join(srclibpathDir, "Srclib.Nuget")
 	log.Println("Downloading toolchain dependencies in", nugetdir)
-	if err := execCmdInDir("dnu", "restore", nugetdir); err != nil {
+	if err := execCmdInDir(nugetdir, "dnu", "restore"); err != nil {
 		return err
 	}
 

--- a/graph/repo.go
+++ b/graph/repo.go
@@ -51,8 +51,6 @@ func TryMakeURI(cloneURL string) (string, error) {
 	url, err := url.Parse(cloneURL)
 	if err != nil {
 		return "", err
-	} else if url.Path == "" || url.Path == "/" {
-		return "", fmt.Errorf("determining URI from repo clone URL failed: missing path from URL (%q)", cloneURL)
 	} else if url.Host == "" && (url.Path[0] == '/' || !strings.Contains(strings.Trim(url.Path, "/"), "/")) {
 		// We ensure our Path doesn't look like the output of TryMakeURI
 		// so that the output of this function is a fixed point.
@@ -62,7 +60,9 @@ func TryMakeURI(cloneURL string) (string, error) {
 	}
 
 	uri := strings.TrimSuffix(url.Path, ".git")
-	uri = path.Clean(uri)
+	if uri != "" {
+		uri = path.Clean(uri)
+	}
 	uri = strings.TrimSuffix(uri, "/")
 	return strings.ToLower(url.Host) + uri, nil
 }

--- a/graph/repo_test.go
+++ b/graph/repo_test.go
@@ -18,6 +18,9 @@ func TestTryMakeURI(t *testing.T) {
 		{"https://github.com/foo/bar", "github.com/foo/bar", false},
 		{"https://bitbucket.org/foo/bar", "bitbucket.org/foo/bar", false},
 
+		{"https://foobar.com", "foobar.com", false},
+		{"https://foobar.com/", "foobar.com", false},
+
 		{"scm:git:git://github.com/path_to_repository", "github.com/path_to_repository", false},
 		{"scm:git:http://github.com/path_to_repository", "github.com/path_to_repository", false},
 		{"scm:git:https://github.com/path_to_repository", "github.com/path_to_repository", false},


### PR DESCRIPTION
- excluding files not listed in the source unit when computing file score, otherwise it may exceed 1, see sourcegraph/srclib-javascript#41
- excluding some files when scanning them (auto-generated, temporary etc)
- when ref's DefUnitType set to "URL" assume it resolved
- added support of RepoURI that contains empty path component (for example, "URL"-type defs usually have hostname.com as RepoURI)
- Corrected installation of C# toolchain