### PR TITLE
gendata: Remove unneeded fmt.Sprintf.

### DIFF
--- a/gendata/simple.go
+++ b/gendata/simple.go
@@ -36,7 +36,7 @@ func (c *SimpleRepoCmd) Execute(args []string) error {
 	for _, unitName := range unitNames {
 		units = append(units, &unit.SourceUnit{
 			Key: unit.Key{
-				Name:     fmt.Sprintf(unitName),
+				Name:     unitName,
 				Type:     "GoPackage",
 				Repo:     c.Repo,
 				CommitID: c.CommitID,

--- a/gendata/urefs.go
+++ b/gendata/urefs.go
@@ -42,7 +42,7 @@ func (c *URefsRepoCmd) Execute(args []string) error {
 	for _, unitName := range unitNames {
 		ut := &unit.SourceUnit{
 			Key: unit.Key{
-				Name:     fmt.Sprintf(unitName),
+				Name:     unitName,
 				Type:     "GoPackage",
 				Repo:     c.Repo,
 				CommitID: c.CommitID,


### PR DESCRIPTION
Don't use `fmt.Sprintf` here since it's not needed.

It's dangerous to provide dynamic input as the first parameter of a printf-like function since it may contain a sequence like `%v` which would cause a problem.