### PR TITLE
README: fix typos in goxc path

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ instructions.
 Contributors with deploy privileges can update the official binaries
 via these instructions:
 
-1. `go install github.com/laxer/goxc`
+1. `go get -u github.com/laher/goxc`
 1. Ensure you have the AWS credentials set so that the AWS CLI (`aws`) can write to the `srclib-release` S3 bucket.
 1. Run `make release V=1.2.3`, where `1.2.3` is the version you want to release (which can be arbitrarily chosen but should be the next sequential git release tag for official releases).
 


### PR DESCRIPTION
The developer instructions contains instructions to install `goxc` utility, there's a minor typo in the import path and users should `go get` the path in order to fetch and install, not `go install` which requires the path to exist locally.